### PR TITLE
feat: add mood-based recommendations

### DIFF
--- a/__tests__/engines-genre-random.test.ts
+++ b/__tests__/engines-genre-random.test.ts
@@ -151,6 +151,38 @@ describe("genreEngine", () => {
     expect(mockDiscoverByGenre).not.toHaveBeenCalledWith(18);
   });
 
+  it("treats user_rating=0 as unrated (default weight 5), not disliked", async () => {
+    // user_rating=0 means "not yet rated" throughout the codebase — it should
+    // contribute the same default weight as null, not be excluded as disliked.
+    const library = [
+      makeMovie({ id: 1, title: "Unrated Drama", genre: "Drama", user_rating: 0 }),
+    ];
+    const ctx = buildContext(library, new Set());
+    mockGenreNameToId.mockReturnValue(18);
+    mockDiscoverByGenre.mockResolvedValue([makeResult({ tmdb_id: 500, title: "Found Drama" })]);
+
+    const result = await genreEngine(ctx);
+    expect(result).toHaveLength(1);
+    expect(result[0].reason).toContain("Drama");
+    expect(mockDiscoverByGenre).toHaveBeenCalledWith(18);
+  });
+
+  it("unrated (user_rating=0) and null-rated movies contribute equal weight to genre scoring", async () => {
+    const library = [
+      makeMovie({ id: 1, title: "Null Rated", genre: "Drama", user_rating: undefined }),
+      makeMovie({ id: 2, title: "Zero Rated", genre: "Drama", user_rating: 0 }),
+    ];
+    const ctx = buildContext(library, new Set());
+    mockGenreNameToId.mockReturnValue(18);
+    mockDiscoverByGenre.mockResolvedValue([makeResult({ tmdb_id: 500, title: "Drama Film" })]);
+
+    const result = await genreEngine(ctx);
+    expect(result).toHaveLength(1);
+    // Both movies contribute weight 5 each = total 10 for Drama
+    expect(mockDiscoverByGenre).toHaveBeenCalledTimes(1);
+    expect(mockDiscoverByGenre).toHaveBeenCalledWith(18);
+  });
+
   it("skips genres marked as 'Unknown'", async () => {
     const library = [makeMovie({ id: 1, title: "Film", genre: "Unknown", user_rating: 8 })];
     const ctx = buildContext(library, new Set());

--- a/__tests__/engines-mood.test.ts
+++ b/__tests__/engines-mood.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { buildContext } from "@/lib/engines";
+import type { Movie } from "@/lib/db";
+import type { TmdbSearchResult } from "@/lib/tmdb";
+import { MOOD_PRESETS, MOOD_KEYS } from "@/lib/mood-presets";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockDiscoverByMood } = vi.hoisted(() => ({
+  mockDiscoverByMood: vi.fn(),
+}));
+
+vi.mock("@/lib/tmdb", () => ({
+  discoverByMood: mockDiscoverByMood,
+}));
+
+import { moodEngine } from "@/lib/engines/mood";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMovie(
+  overrides: Partial<Movie> & { id: number; title: string },
+): Movie {
+  return {
+    year: 2010,
+    genre: "Drama",
+    director: null,
+    writer: null,
+    actors: null,
+    rating: 7.5,
+    poster_url: null,
+    source: "tmdb",
+    imdb_id: null,
+    tmdb_id: overrides.id * 100,
+    type: "movie",
+    file_path: null,
+    extra_files: null,
+    created_at: "2026-01-01",
+    ...overrides,
+  } as Movie;
+}
+
+function makeResult(
+  overrides: Partial<TmdbSearchResult> & { tmdb_id: number; title: string },
+): TmdbSearchResult {
+  return {
+    year: 2020,
+    genre: "Drama",
+    rating: 7.5,
+    poster_url: null,
+    imdb_id: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockDiscoverByMood.mockResolvedValue([]);
+});
+
+// ---------------------------------------------------------------------------
+// MOOD_PRESETS
+// ---------------------------------------------------------------------------
+
+describe("MOOD_PRESETS", () => {
+  it("has at least 6 presets", () => {
+    expect(MOOD_KEYS.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("each preset has label, icon, and reason", () => {
+    for (const key of MOOD_KEYS) {
+      const preset = MOOD_PRESETS[key];
+      expect(preset.label).toBeTruthy();
+      expect(preset.icon).toBeTruthy();
+      expect(preset.reason).toBeTruthy();
+    }
+  });
+
+  it("comfort_rewatch has comfortRewatch flag", () => {
+    expect(MOOD_PRESETS.comfort_rewatch.comfortRewatch).toBe(true);
+  });
+
+  it("foreign preset has languages array", () => {
+    expect(MOOD_PRESETS.foreign.languages?.length).toBeGreaterThan(0);
+  });
+
+  it("short preset has maxRuntime", () => {
+    expect(MOOD_PRESETS.short.maxRuntime).toBeLessThanOrEqual(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// moodEngine — TMDb-backed moods
+// ---------------------------------------------------------------------------
+
+describe("moodEngine (TMDb-backed)", () => {
+  it("returns empty when discoverByMood yields no results", async () => {
+    const library = [makeMovie({ id: 1, title: "Film", genre: "Comedy", user_rating: 8 })];
+    const ctx = buildContext(library, new Set());
+    mockDiscoverByMood.mockResolvedValue([]);
+    expect(await moodEngine(ctx, "light_funny")).toEqual([]);
+  });
+
+  it("returns a single group with type 'mood'", async () => {
+    const library = [makeMovie({ id: 1, title: "Film A", genre: "Comedy" })];
+    const ctx = buildContext(library, new Set());
+    mockDiscoverByMood.mockResolvedValue([
+      makeResult({ tmdb_id: 500, title: "Funny Movie" }),
+    ]);
+
+    const result = await moodEngine(ctx, "light_funny");
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("mood");
+    expect(result[0].reason).toBeTruthy();
+    expect(result[0].recommendations[0].title).toBe("Funny Movie");
+  });
+
+  it("excludes movies already in library", async () => {
+    const library = [makeMovie({ id: 1, title: "Film A", tmdb_id: 100 })];
+    const ctx = buildContext(library, new Set());
+    mockDiscoverByMood.mockResolvedValue([
+      makeResult({ tmdb_id: 100, title: "Film A" }),
+      makeResult({ tmdb_id: 200, title: "New Film" }),
+    ]);
+
+    const result = await moodEngine(ctx, "light_funny");
+    const titles = result[0].recommendations.map((r) => r.title);
+    expect(titles).not.toContain("Film A");
+    expect(titles).toContain("New Film");
+  });
+
+  it("excludes dismissed movies", async () => {
+    const library = [makeMovie({ id: 1, title: "Film A" })];
+    const ctx = buildContext(library, new Set([999]));
+    mockDiscoverByMood.mockResolvedValue([
+      makeResult({ tmdb_id: 999, title: "Dismissed" }),
+      makeResult({ tmdb_id: 888, title: "Visible" }),
+    ]);
+
+    const result = await moodEngine(ctx, "mind_bender");
+    const titles = result[0].recommendations.map((r) => r.title);
+    expect(titles).not.toContain("Dismissed");
+    expect(titles).toContain("Visible");
+  });
+
+  it("limits results to 30", async () => {
+    const library = [makeMovie({ id: 1, title: "Film A" })];
+    const ctx = buildContext(library, new Set());
+    mockDiscoverByMood.mockResolvedValue(
+      Array.from({ length: 50 }, (_, i) =>
+        makeResult({ tmdb_id: i + 1, title: `Film ${i}` }),
+      ),
+    );
+
+    const result = await moodEngine(ctx, "feel_good");
+    expect(result[0].recommendations).toHaveLength(30);
+  });
+
+  it("passes preset genreIds to discoverByMood", async () => {
+    const library = [makeMovie({ id: 1, title: "Film A" })];
+    const ctx = buildContext(library, new Set());
+    await moodEngine(ctx, "light_funny");
+
+    expect(mockDiscoverByMood).toHaveBeenCalledWith(
+      expect.objectContaining({
+        genreIds: MOOD_PRESETS.light_funny.genreIds,
+      }),
+    );
+  });
+
+  it("passes maxRuntime for short mood", async () => {
+    const library = [makeMovie({ id: 1, title: "Film A" })];
+    const ctx = buildContext(library, new Set());
+    await moodEngine(ctx, "short");
+
+    expect(mockDiscoverByMood).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxRuntime: MOOD_PRESETS.short.maxRuntime,
+      }),
+    );
+  });
+
+  it("passes languages for foreign mood", async () => {
+    const library = [makeMovie({ id: 1, title: "Film A" })];
+    const ctx = buildContext(library, new Set());
+    await moodEngine(ctx, "foreign");
+
+    expect(mockDiscoverByMood).toHaveBeenCalledWith(
+      expect.objectContaining({
+        languages: MOOD_PRESETS.foreign.languages,
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// moodEngine — comfort_rewatch (library-backed)
+// ---------------------------------------------------------------------------
+
+describe("moodEngine (comfort_rewatch)", () => {
+  it("returns empty when library is empty", async () => {
+    const ctx = buildContext([], new Set());
+    expect(await moodEngine(ctx, "comfort_rewatch")).toEqual([]);
+    expect(mockDiscoverByMood).not.toHaveBeenCalled();
+  });
+
+  it("does not call discoverByMood", async () => {
+    const library = [makeMovie({ id: 1, title: "Fav Film", tmdb_id: 100, user_rating: 9 })];
+    const ctx = buildContext(library, new Set());
+    await moodEngine(ctx, "comfort_rewatch");
+    expect(mockDiscoverByMood).not.toHaveBeenCalled();
+  });
+
+  it("includes highly-rated library movies (user_rating >= 8)", async () => {
+    const library = [
+      makeMovie({ id: 1, title: "Top Pick", tmdb_id: 100, user_rating: 9 }),
+      makeMovie({ id: 2, title: "Low Rated", tmdb_id: 200, user_rating: 4 }),
+    ];
+    const ctx = buildContext(library, new Set());
+    const result = await moodEngine(ctx, "comfort_rewatch");
+    const titles = result[0].recommendations.map((r) => r.title);
+    expect(titles).toContain("Top Pick");
+    expect(titles).not.toContain("Low Rated");
+  });
+
+  it("includes unrated library movies with tmdb rating >= 7", async () => {
+    const library = [
+      makeMovie({ id: 1, title: "Unwatched Good", tmdb_id: 100, rating: 7.8 }),
+      makeMovie({ id: 2, title: "Unwatched Meh", tmdb_id: 200, rating: 5.5 }),
+    ];
+    const ctx = buildContext(library, new Set());
+    const result = await moodEngine(ctx, "comfort_rewatch");
+    const titles = result[0].recommendations.map((r) => r.title);
+    expect(titles).toContain("Unwatched Good");
+    expect(titles).not.toContain("Unwatched Meh");
+  });
+
+  it("treats user_rating=0 as unrated and falls back to tmdb rating", async () => {
+    const library = [
+      makeMovie({ id: 1, title: "Zero Rated Good TMDb", tmdb_id: 100, user_rating: 0, rating: 8.0 }),
+      makeMovie({ id: 2, title: "Zero Rated Bad TMDb", tmdb_id: 200, user_rating: 0, rating: 5.0 }),
+    ];
+    const ctx = buildContext(library, new Set());
+    const result = await moodEngine(ctx, "comfort_rewatch");
+    const titles = result[0].recommendations.map((r) => r.title);
+    expect(titles).toContain("Zero Rated Good TMDb");
+    expect(titles).not.toContain("Zero Rated Bad TMDb");
+  });
+
+  it("excludes dismissed movies", async () => {
+    const library = [
+      makeMovie({ id: 1, title: "Dismissed", tmdb_id: 100, user_rating: 9 }),
+      makeMovie({ id: 2, title: "Kept", tmdb_id: 200, user_rating: 8 }),
+    ];
+    const ctx = buildContext(library, new Set([100]));
+    const result = await moodEngine(ctx, "comfort_rewatch");
+    const titles = result[0].recommendations.map((r) => r.title);
+    expect(titles).not.toContain("Dismissed");
+    expect(titles).toContain("Kept");
+  });
+
+  it("sorts by user_rating desc then tmdb rating desc", async () => {
+    const library = [
+      makeMovie({ id: 1, title: "Mid", tmdb_id: 100, user_rating: 8 }),
+      makeMovie({ id: 2, title: "Best", tmdb_id: 200, user_rating: 10 }),
+      makeMovie({ id: 3, title: "Good", tmdb_id: 300, user_rating: 9 }),
+    ];
+    const ctx = buildContext(library, new Set());
+    const result = await moodEngine(ctx, "comfort_rewatch");
+    const titles = result[0].recommendations.map((r) => r.title);
+    expect(titles[0]).toBe("Best");
+    expect(titles[1]).toBe("Good");
+    expect(titles[2]).toBe("Mid");
+  });
+
+  it("limits comfort picks to 30", async () => {
+    const library = Array.from({ length: 50 }, (_, i) =>
+      makeMovie({ id: i + 1, title: `Film ${i}`, tmdb_id: (i + 1) * 10, user_rating: 9 }),
+    );
+    const ctx = buildContext(library, new Set());
+    const result = await moodEngine(ctx, "comfort_rewatch");
+    expect(result[0].recommendations).toHaveLength(30);
+  });
+
+  it("returns empty when no qualifying movies", async () => {
+    const library = [
+      makeMovie({ id: 1, title: "Meh", tmdb_id: 100, user_rating: 5 }),
+      makeMovie({ id: 2, title: "Bad", tmdb_id: 200, user_rating: 3 }),
+    ];
+    const ctx = buildContext(library, new Set());
+    expect(await moodEngine(ctx, "comfort_rewatch")).toEqual([]);
+  });
+});

--- a/__tests__/engines-mood.test.ts
+++ b/__tests__/engines-mood.test.ts
@@ -195,6 +195,63 @@ describe("moodEngine (TMDb-backed)", () => {
       }),
     );
   });
+
+  it("filters out excluded genres from config", async () => {
+    const library = [makeMovie({ id: 1, title: "Film A" })];
+    const ctx = buildContext(library, new Set(), {
+      excluded_genres: ["Horror"],
+      min_year: null,
+      min_rating: null,
+      max_per_group: 10,
+    });
+    mockDiscoverByMood.mockResolvedValue([
+      makeResult({ tmdb_id: 100, title: "Horror Film", genre: "Horror" }),
+      makeResult({ tmdb_id: 200, title: "Comedy Film", genre: "Comedy" }),
+    ]);
+
+    const result = await moodEngine(ctx, "light_funny");
+    const titles = result[0].recommendations.map((r) => r.title);
+    expect(titles).not.toContain("Horror Film");
+    expect(titles).toContain("Comedy Film");
+  });
+
+  it("filters out movies below min_year from config", async () => {
+    const library = [makeMovie({ id: 1, title: "Film A" })];
+    const ctx = buildContext(library, new Set(), {
+      excluded_genres: [],
+      min_year: 2010,
+      min_rating: null,
+      max_per_group: 10,
+    });
+    mockDiscoverByMood.mockResolvedValue([
+      makeResult({ tmdb_id: 100, title: "Old Film", year: 1990 }),
+      makeResult({ tmdb_id: 200, title: "New Film", year: 2015 }),
+    ]);
+
+    const result = await moodEngine(ctx, "light_funny");
+    const titles = result[0].recommendations.map((r) => r.title);
+    expect(titles).not.toContain("Old Film");
+    expect(titles).toContain("New Film");
+  });
+
+  it("filters out movies below min_rating from config", async () => {
+    const library = [makeMovie({ id: 1, title: "Film A" })];
+    const ctx = buildContext(library, new Set(), {
+      excluded_genres: [],
+      min_year: null,
+      min_rating: 8.0,
+      max_per_group: 10,
+    });
+    mockDiscoverByMood.mockResolvedValue([
+      makeResult({ tmdb_id: 100, title: "Low Rated", rating: 6.0 }),
+      makeResult({ tmdb_id: 200, title: "High Rated", rating: 8.5 }),
+    ]);
+
+    const result = await moodEngine(ctx, "light_funny");
+    const titles = result[0].recommendations.map((r) => r.title);
+    expect(titles).not.toContain("Low Rated");
+    expect(titles).toContain("High Rated");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -293,5 +350,17 @@ describe("moodEngine (comfort_rewatch)", () => {
     ];
     const ctx = buildContext(library, new Set());
     expect(await moodEngine(ctx, "comfort_rewatch")).toEqual([]);
+  });
+
+  it("excludes movies without tmdb_id from comfort picks", async () => {
+    const library = [
+      makeMovie({ id: 1, title: "No ID Film", tmdb_id: undefined as unknown as number, user_rating: 9 }),
+      makeMovie({ id: 2, title: "Has ID Film", tmdb_id: 200, user_rating: 9 }),
+    ];
+    const ctx = buildContext(library, new Set());
+    const result = await moodEngine(ctx, "comfort_rewatch");
+    const titles = result[0].recommendations.map((r) => r.title);
+    expect(titles).not.toContain("No ID Film");
+    expect(titles).toContain("Has ID Film");
   });
 });

--- a/__tests__/mood-api.test.ts
+++ b/__tests__/mood-api.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import Database from "better-sqlite3";
+import path from "path";
+import { unlinkSync } from "fs";
+import { initDb } from "@/lib/db";
+import type { RecommendationGroup } from "@/lib/engines";
+import type { TmdbSearchResult } from "@/lib/tmdb";
+
+const { mockMoodEngine } = vi.hoisted(() => ({
+  mockMoodEngine: vi.fn<() => Promise<RecommendationGroup[]>>(),
+}));
+
+vi.mock("@/lib/engines/mood", () => ({
+  moodEngine: mockMoodEngine,
+}));
+
+vi.mock("@/lib/engines", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/engines")>();
+  return {
+    ...actual,
+    getCdaLookup: vi.fn(() => ({
+      byTmdbId: new Map<number, string>(),
+      byTitle: new Map<string, string>(),
+    })),
+    enrichWithCda: vi.fn((results: TmdbSearchResult[]) => results),
+  };
+});
+
+vi.mock("@/lib/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/db")>();
+  return { ...actual, getDb: vi.fn() };
+});
+
+import { GET } from "@/app/api/recommendations/mood/route";
+import { getDb } from "@/lib/db";
+
+const TEST_DB = path.join(__dirname, "test-mood-api.db");
+
+function makeRec(
+  overrides: Partial<TmdbSearchResult> & { tmdb_id: number; title: string },
+): TmdbSearchResult {
+  return { year: 2020, genre: "Drama", rating: 7.5, poster_url: null, imdb_id: null, ...overrides };
+}
+
+describe("GET /api/recommendations/mood", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(TEST_DB);
+    initDb(db);
+    vi.mocked(getDb).mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+    mockMoodEngine.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    db.close();
+    try { unlinkSync(TEST_DB); } catch {}
+  });
+
+  it("returns 400 when key param is missing", async () => {
+    const req = new NextRequest("http://localhost/api/recommendations/mood");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid mood key/i);
+  });
+
+  it("returns 400 when key is not a valid mood key", async () => {
+    const req = new NextRequest("http://localhost/api/recommendations/mood?key=invalid_key");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid mood key/i);
+  });
+
+  it("returns 200 with empty array when engine returns no results", async () => {
+    mockMoodEngine.mockResolvedValue([]);
+    const req = new NextRequest("http://localhost/api/recommendations/mood?key=light_funny");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it("returns groups from moodEngine", async () => {
+    const group: RecommendationGroup = {
+      reason: "Light & funny tonight",
+      type: "mood",
+      recommendations: [makeRec({ tmdb_id: 1, title: "Funny Movie" })],
+    };
+    mockMoodEngine.mockResolvedValue([group]);
+    const req = new NextRequest("http://localhost/api/recommendations/mood?key=light_funny");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].recommendations[0].title).toBe("Funny Movie");
+  });
+
+  it("calls moodEngine with the correct key", async () => {
+    const req = new NextRequest("http://localhost/api/recommendations/mood?key=mind_bender");
+    await GET(req);
+    expect(mockMoodEngine).toHaveBeenCalledWith(expect.anything(), "mind_bender");
+  });
+
+  it("returns 500 when moodEngine throws", async () => {
+    mockMoodEngine.mockRejectedValue(new Error("TMDb down"));
+    const req = new NextRequest("http://localhost/api/recommendations/mood?key=feel_good");
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("TMDb down");
+  });
+
+  it("accepts all valid mood keys", async () => {
+    const keys = ["light_funny", "mind_bender", "comfort_rewatch", "date_night", "dark_heavy", "short", "foreign", "feel_good"];
+    for (const key of keys) {
+      const req = new NextRequest(`http://localhost/api/recommendations/mood?key=${key}`);
+      const res = await GET(req);
+      expect(res.status).toBe(200);
+    }
+  });
+});

--- a/__tests__/stream-api.test.ts
+++ b/__tests__/stream-api.test.ts
@@ -236,5 +236,31 @@ describe("movies/[id]/stream GET handler", () => {
       const text = await res.text();
       expect(text).toMatch(/subtitle not found/i);
     });
+
+    it("rejects path traversal via .. segments", async () => {
+      const res = await GET(getReq(movieId, { sub: "../secret.txt" }), makeParams(movieId));
+      expect(res.status).toBe(400);
+      const text = await res.text();
+      expect(text).toMatch(/invalid subtitle path/i);
+      expect(mockReadFile).not.toHaveBeenCalled();
+    });
+
+    it("rejects deeply nested path traversal", async () => {
+      const res = await GET(getReq(movieId, { sub: "../../etc/passwd" }), makeParams(movieId));
+      expect(res.status).toBe(400);
+      expect(mockReadFile).not.toHaveBeenCalled();
+    });
+
+    it("allows subtitle in a valid subdirectory", async () => {
+      const vttContent = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nSub";
+      mockReadFile.mockResolvedValue(vttContent);
+
+      const res = await GET(getReq(movieId, { sub: "subs/Dune.vtt" }), makeParams(movieId));
+      expect(res.status).toBe(200);
+      expect(mockReadFile).toHaveBeenCalledWith(
+        path.join(SUB_DIR, "subs/Dune.vtt"),
+        "utf-8",
+      );
+    });
   });
 });

--- a/__tests__/tmdb-discover.test.ts
+++ b/__tests__/tmdb-discover.test.ts
@@ -5,6 +5,7 @@ import {
   discoverHiddenGems,
   discoverStarStudded,
   discoverRandom,
+  discoverByMood,
   getTmdbMovieDetails,
   getMovieCredits,
   getMovieLocalized,
@@ -200,6 +201,135 @@ describe("discoverRandom", () => {
     expect(mockFetch).toHaveBeenCalledTimes(3);
     const firstUrl = mockFetch.mock.calls[0][0] as string;
     expect(firstUrl).toContain("vote_average.gte=6.5");
+  });
+});
+
+describe("discoverByMood", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.TMDB_API_KEY = "test-key";
+  });
+
+  it("fetches 3 pages by default and returns aggregated results", async () => {
+    mockFetch
+      .mockResolvedValueOnce(okPage([rawMovie(1, "Comedy A")]))
+      .mockResolvedValueOnce(okPage([rawMovie(2, "Comedy B")]))
+      .mockResolvedValueOnce(okPage([rawMovie(3, "Comedy C")]));
+
+    const results = await discoverByMood({ genreIds: [35], minRating: 6.5, minVotes: 200 });
+
+    expect(results).toHaveLength(3);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("includes with_genres in URL when genreIds provided", async () => {
+    mockFetch.mockResolvedValue(okPage([]));
+
+    await discoverByMood({ genreIds: [35, 10751] });
+
+    const firstUrl = mockFetch.mock.calls[0][0] as string;
+    expect(firstUrl).toContain("with_genres=35,10751");
+  });
+
+  it("does not include with_genres in URL when genreIds is omitted", async () => {
+    mockFetch.mockResolvedValue(okPage([]));
+
+    await discoverByMood({ languages: ["fr"] });
+
+    const firstUrl = mockFetch.mock.calls[0][0] as string;
+    expect(firstUrl).not.toContain("with_genres");
+  });
+
+  it("applies minRating and minVotes to URL", async () => {
+    mockFetch.mockResolvedValue(okPage([]));
+
+    await discoverByMood({ minRating: 7.5, minVotes: 500 });
+
+    const firstUrl = mockFetch.mock.calls[0][0] as string;
+    expect(firstUrl).toContain("vote_average.gte=7.5");
+    expect(firstUrl).toContain("vote_count.gte=500");
+  });
+
+  it("uses default minRating=6.5 and minVotes=200 when not specified", async () => {
+    mockFetch.mockResolvedValue(okPage([]));
+
+    await discoverByMood({});
+
+    const firstUrl = mockFetch.mock.calls[0][0] as string;
+    expect(firstUrl).toContain("vote_average.gte=6.5");
+    expect(firstUrl).toContain("vote_count.gte=200");
+  });
+
+  it("appends with_runtime.lte when maxRuntime is provided", async () => {
+    mockFetch.mockResolvedValue(okPage([]));
+
+    await discoverByMood({ maxRuntime: 100 });
+
+    const firstUrl = mockFetch.mock.calls[0][0] as string;
+    expect(firstUrl).toContain("with_runtime.lte=100");
+  });
+
+  it("does not append with_runtime.lte when maxRuntime is omitted", async () => {
+    mockFetch.mockResolvedValue(okPage([]));
+
+    await discoverByMood({});
+
+    const firstUrl = mockFetch.mock.calls[0][0] as string;
+    expect(firstUrl).not.toContain("with_runtime");
+  });
+
+  it("fetches separate pages per language and aggregates all results", async () => {
+    mockFetch
+      .mockResolvedValueOnce(okPage([rawMovie(10, "French Film")]))
+      .mockResolvedValueOnce(okPage([rawMovie(11, "French Film 2")]))
+      .mockResolvedValueOnce(okPage([rawMovie(12, "French Film 3")]))
+      .mockResolvedValueOnce(okPage([rawMovie(20, "Japanese Film")]))
+      .mockResolvedValueOnce(okPage([rawMovie(21, "Japanese Film 2")]))
+      .mockResolvedValueOnce(okPage([rawMovie(22, "Japanese Film 3")]));
+
+    const results = await discoverByMood({ languages: ["fr", "ja"], pages: 3 });
+
+    expect(results).toHaveLength(6);
+    expect(mockFetch).toHaveBeenCalledTimes(6);
+  });
+
+  it("adds with_original_language to URL for each language", async () => {
+    mockFetch.mockResolvedValue(okPage([]));
+
+    await discoverByMood({ languages: ["ko"], pages: 1 });
+
+    const firstUrl = mockFetch.mock.calls[0][0] as string;
+    expect(firstUrl).toContain("with_original_language=ko");
+  });
+
+  it("respects custom pages parameter", async () => {
+    mockFetch
+      .mockResolvedValueOnce(okPage([rawMovie(1, "Film 1")]))
+      .mockResolvedValueOnce(okPage([rawMovie(2, "Film 2")]));
+
+    const results = await discoverByMood({ pages: 2 });
+
+    expect(results).toHaveLength(2);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops fetching after a non-ok response", async () => {
+    mockFetch
+      .mockResolvedValueOnce(okPage([rawMovie(1, "Film A")]))
+      .mockResolvedValueOnce({ ok: false, status: 429 })
+      .mockResolvedValueOnce(okPage([rawMovie(3, "Film C")]));
+
+    const results = await discoverByMood({});
+
+    expect(results).toHaveLength(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns empty array when first page fails", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+
+    const results = await discoverByMood({ genreIds: [28] });
+    expect(results).toEqual([]);
   });
 });
 

--- a/__tests__/tv-blacklist-api.test.ts
+++ b/__tests__/tv-blacklist-api.test.ts
@@ -93,5 +93,29 @@ describe("TV blacklist API", () => {
       const data = await res.json();
       expect(data).toEqual(ids);
     });
+
+    it("returns 400 when body is not an array", async () => {
+      const req = new Request("http://localhost/api/tv/blacklist", {
+        method: "PUT",
+        body: JSON.stringify({ channels: ["ch1"] }),
+        headers: { "content-type": "application/json" },
+      });
+      const res = await PUT(req);
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toMatch(/array/i);
+    });
+
+    it("returns 400 when body contains non-string items", async () => {
+      const req = new Request("http://localhost/api/tv/blacklist", {
+        method: "PUT",
+        body: JSON.stringify(["valid", 123, null]),
+        headers: { "content-type": "application/json" },
+      });
+      const res = await PUT(req);
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toMatch(/string/i);
+    });
   });
 });

--- a/__tests__/tv-enrich-api.test.ts
+++ b/__tests__/tv-enrich-api.test.ts
@@ -109,4 +109,43 @@ describe("POST /api/tv/enrich", () => {
     const res = await POST(makeRequest(["Status Check"]));
     expect(res.status).toBe(200);
   });
+
+  it("returns 400 when titles is not an array", async () => {
+    const req = new Request("http://localhost/api/tv/enrich", {
+      method: "POST",
+      body: JSON.stringify({ titles: "not an array" }),
+      headers: { "content-type": "application/json" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/array/i);
+    expect(searchTmdb).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when titles contains non-string items", async () => {
+    const req = new Request("http://localhost/api/tv/enrich", {
+      method: "POST",
+      body: JSON.stringify({ titles: ["valid", 42, null] }),
+      headers: { "content-type": "application/json" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/string/i);
+    expect(searchTmdb).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when titles array exceeds 500 items", async () => {
+    const req = new Request("http://localhost/api/tv/enrich", {
+      method: "POST",
+      body: JSON.stringify({ titles: Array.from({ length: 501 }, (_, i) => `Film ${i}`) }),
+      headers: { "content-type": "application/json" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/500/);
+    expect(searchTmdb).not.toHaveBeenCalled();
+  });
 });

--- a/app/api/movies/[id]/stream/route.ts
+++ b/app/api/movies/[id]/stream/route.ts
@@ -32,7 +32,12 @@ export async function GET(
     const subName = req.nextUrl.searchParams.get("sub");
 
     if (subName) {
-      const subPath = path.join(path.dirname(activeFilePath), subName);
+      const movieDir = path.dirname(activeFilePath);
+      const subPath = path.join(movieDir, subName);
+      // Prevent path traversal: resolved subtitle must stay within the movie's directory
+      if (!path.resolve(subPath).startsWith(path.resolve(movieDir) + path.sep)) {
+        return new NextResponse("Invalid subtitle path", { status: 400 });
+      }
       try {
         let subContent = await fs.promises.readFile(subPath, "utf-8");
 

--- a/app/api/movies/route.ts
+++ b/app/api/movies/route.ts
@@ -52,7 +52,9 @@ export async function POST(request: NextRequest) {
         id,
       );
     }
-  } catch {}
+  } catch (e) {
+    console.warn("[Movies POST] optional column update failed:", e);
+  }
 
   return Response.json({ id }, { status: 201 });
 }

--- a/app/api/pl-title/route.ts
+++ b/app/api/pl-title/route.ts
@@ -24,14 +24,18 @@ export async function GET(request: NextRequest) {
         db.prepare(
           "UPDATE movies SET pl_title = ? WHERE tmdb_id = ? AND pl_title IS NULL",
         ).run(pl_title, tmdbId);
-      } catch {}
+      } catch (e) {
+        console.warn("[pl-title] pl_title column update failed:", e);
+      }
     }
     if (description) {
       try {
         db.prepare(
           "UPDATE movies SET description = ? WHERE tmdb_id = ? AND description IS NULL",
         ).run(description, tmdbId);
-      } catch {}
+      } catch (e) {
+        console.warn("[pl-title] description column update failed:", e);
+      }
     }
   }
 

--- a/app/api/recommendations/mood/route.ts
+++ b/app/api/recommendations/mood/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from "next/server";
+import { getDb, getMovies, getDismissedIds, getSetting } from "@/lib/db";
+import { buildContext, getCdaLookup, enrichWithCda, type RecConfig } from "@/lib/engines";
+import { moodEngine } from "@/lib/engines/mood";
+import { MOOD_PRESETS, type MoodKey } from "@/lib/mood-presets";
+
+export async function GET(request: NextRequest) {
+  const moodKey = request.nextUrl.searchParams.get("key") as MoodKey | null;
+  if (!moodKey || !(moodKey in MOOD_PRESETS)) {
+    return Response.json({ error: "invalid mood key" }, { status: 400 });
+  }
+
+  const db = getDb();
+  const allMovies = getMovies(db);
+  const movies = allMovies.filter((m) => m.source !== "recommendation");
+  const dismissedIds = getDismissedIds(db);
+  const cdaLookup = getCdaLookup();
+
+  const configRaw = getSetting(db, "rec_config");
+  const config: RecConfig | undefined = configRaw
+    ? (() => { try { return JSON.parse(configRaw); } catch { return undefined; } })()
+    : undefined;
+
+  const ctx = buildContext(movies, dismissedIds, config);
+
+  let groups;
+  try {
+    groups = await moodEngine(ctx, moodKey);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    return Response.json({ error: message }, { status: 500 });
+  }
+
+  const enriched = groups.map((g) => ({
+    ...g,
+    recommendations: enrichWithCda(g.recommendations, cdaLookup),
+  }));
+
+  return Response.json(enriched);
+}

--- a/app/api/tv/blacklist/route.ts
+++ b/app/api/tv/blacklist/route.ts
@@ -9,7 +9,15 @@ export async function GET() {
 
 export async function PUT(request: Request) {
   const db = getDb();
-  const list = (await request.json()) as string[];
-  setSetting(db, "tv_channel_blacklist", JSON.stringify(list));
+  const body = await request.json();
+
+  if (!Array.isArray(body)) {
+    return Response.json({ error: "body must be an array" }, { status: 400 });
+  }
+  if (body.some((item) => typeof item !== "string")) {
+    return Response.json({ error: "all items must be strings" }, { status: 400 });
+  }
+
+  setSetting(db, "tv_channel_blacklist", JSON.stringify(body as string[]));
   return Response.json({ ok: true });
 }

--- a/app/api/tv/enrich/route.ts
+++ b/app/api/tv/enrich/route.ts
@@ -8,7 +8,18 @@ interface EnrichResult {
 const cache = new Map<string, EnrichResult>();
 
 export async function POST(request: Request) {
-  const { titles } = (await request.json()) as { titles: string[] };
+  const body = await request.json();
+  const { titles } = body as { titles: unknown };
+
+  if (!Array.isArray(titles)) {
+    return Response.json({ error: "titles must be an array" }, { status: 400 });
+  }
+  if (titles.length > 500) {
+    return Response.json({ error: "too many titles (max 500)" }, { status: 400 });
+  }
+  if (titles.some((t) => typeof t !== "string")) {
+    return Response.json({ error: "all titles must be strings" }, { status: 400 });
+  }
 
   const result: Record<string, EnrichResult> = {};
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ import ConfigPanel, { type RecConfig } from "@/components/ConfigPanel";
 import TvTab from "@/components/TvTab";
 import PersonView from "@/components/PersonView";
 import { ToastContainer } from "@/components/Toast";
+import { MOOD_PRESETS, MOOD_KEYS, type MoodKey } from "@/lib/mood-presets";
 
 type SortOption =
   | "user_rating"
@@ -56,7 +57,8 @@ type RecType =
   | "hidden_gem"
   | "star_studded"
   | "random"
-  | "cda";
+  | "cda"
+  | "mood";
 
 interface RecommendationGroup {
   reason: string;
@@ -104,7 +106,7 @@ function formatRefreshTime(iso: string): string {
   return date.toLocaleDateString("en", { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" });
 }
 
-function parseHash(): { tab: AppTab; category: string } {
+function parseHash(): { tab: AppTab; category: string; moodKey?: MoodKey } {
   if (typeof window === "undefined") return { tab: "recommendations", category: "all" };
   const hash = window.location.hash.replace("#", "");
   if (hash === "wishlist") return { tab: "wishlist", category: "all" };
@@ -113,6 +115,12 @@ function parseHash(): { tab: AppTab; category: string } {
   if (hash.startsWith("search/")) return { tab: "search", category: decodeURIComponent(hash.substring(7)) };
   if (hash.startsWith("recommendations")) {
     const parts = hash.split("/");
+    if (parts[1] === "mood" && parts[2] && parts[2] in MOOD_PRESETS) {
+      return { tab: "recommendations", category: "all", moodKey: parts[2] as MoodKey };
+    }
+    if (parts[1] === "mood") {
+      return { tab: "recommendations", category: "all" };
+    }
     return { tab: "recommendations", category: parts[1] || "all" };
   }
   if (hash.startsWith("person/")) {
@@ -177,6 +185,10 @@ export default function Home() {
 
   // Rec state
   const [recCategory, setRecCategory] = useState("all");
+  const [activeMood, setActiveMood] = useState<MoodKey | null>(null);
+  const [moodGroups, setMoodGroups] = useState<RecommendationGroup[]>([]);
+  const [moodLoading, setMoodLoading] = useState(false);
+  const [moodError, setMoodError] = useState<string | null>(null);
   const [recConfig, setRecConfig] = useState<RecConfig>({
     excluded_genres: [],
     min_year: null,
@@ -192,12 +204,15 @@ export default function Home() {
 
   // Read hash on mount (after hydration to avoid mismatch)
   useEffect(() => {
-    const { tab, category } = parseHash();
+    const { tab, category, moodKey } = parseHash();
     // Don't restore search tab on mount — it has no cached results
     if (tab === "search") return;
     if (tab !== "recommendations") setActiveTab(tab);
     if (tab === "person") setPersonFilter(category);
-    else if (tab === "recommendations" && category !== "all") setRecCategory(category);
+    else if (tab === "recommendations") {
+      if (moodKey) setActiveMood(moodKey);
+      else if (category !== "all") setRecCategory(category);
+    }
   }, []);
 
   // Sync URL hash with state
@@ -215,28 +230,55 @@ export default function Home() {
                 ? "#config"
                 : activeTab === "tv"
                   ? "#tv"
-                  : recCategory === "all"
-                    ? "#recommendations"
-                    : `#recommendations/${recCategory}`;
+                  : activeMood
+                    ? `#recommendations/mood/${activeMood}`
+                    : recCategory === "all"
+                      ? "#recommendations"
+                      : `#recommendations/${recCategory}`;
     if (window.location.hash !== hash) {
       window.history.replaceState(null, "", hash);
     }
-  }, [activeTab, recCategory, personFilter, searchQuery]);
+  }, [activeTab, recCategory, activeMood, personFilter, searchQuery]);
 
   // Handle browser back/forward
   useEffect(() => {
     function onHashChange() {
-      const { tab, category } = parseHash();
+      const { tab, category, moodKey } = parseHash();
       setActiveTab(tab);
       if (tab === "person") {
         setPersonFilter(category);
       } else {
+        setActiveMood(moodKey ?? null);
         setRecCategory(category);
       }
     }
     window.addEventListener("hashchange", onHashChange);
     return () => window.removeEventListener("hashchange", onHashChange);
   }, []);
+
+  // Fetch mood results when activeMood changes
+  useEffect(() => {
+    if (!activeMood) {
+      setMoodGroups([]);
+      setMoodError(null);
+      return;
+    }
+    setMoodLoading(true);
+    setMoodError(null);
+    fetch(`/api/recommendations/mood?key=${activeMood}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`Request failed (${r.status})`);
+        return r.json();
+      })
+      .then((data: RecommendationGroup[]) => {
+        setMoodGroups(data);
+        setMoodLoading(false);
+      })
+      .catch((err: unknown) => {
+        setMoodError(err instanceof Error ? err.message : "Failed to load mood picks");
+        setMoodLoading(false);
+      });
+  }, [activeMood]);
 
   const recommendations = useMemo(() => {
     // Filter out movies the user has already rated
@@ -797,11 +839,21 @@ export default function Home() {
       }
       return next;
     });
+    setMoodGroups((prev) =>
+      prev
+        .map((g) => ({
+          ...g,
+          recommendations: g.recommendations.filter(
+            (r) => r.tmdb_id !== tmdbId && (!title || r.title !== title),
+          ),
+        }))
+        .filter((g) => g.recommendations.length > 0),
+    );
   }
 
-  async function handleRecAction(tmdbId: number, action: string, rec: TmdbSearchResult) {
+  async function handleRecAction(tmdbId: number, action: string, rec: TmdbSearchResult, fromMood = false) {
     removeFromView(tmdbId, rec.title);
-    setTotalRecsCount((c) => Math.max(0, c - 1));
+    if (!fromMood) setTotalRecsCount((c) => Math.max(0, c - 1));
 
     const actionLabels: Record<string, string> = {
       liked: `Liked "${rec.title}" — added to library`,
@@ -1446,46 +1498,128 @@ export default function Home() {
               </div>
             ) : (
               <>
-                {/* Category tabs + CDA toggle */}
-                <div className="flex items-center justify-between gap-4">
-                  <div className="flex gap-1 overflow-x-auto bg-gray-800/40 p-1 rounded-xl">
-                    {REC_CATEGORIES.filter((cat) => cat.value === "all" || !disabledEngines.includes(cat.value)).map((cat) => (
+                {/* Mood chips */}
+                <div className="flex gap-2 overflow-x-auto pb-1">
+                  {MOOD_KEYS.map((key) => {
+                    const preset = MOOD_PRESETS[key];
+                    const isActive = activeMood === key;
+                    return (
                       <button
-                        key={cat.value}
-                        onClick={() => setRecCategory(cat.value)}
-                        className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-all whitespace-nowrap flex items-center gap-1.5 ${
-                          recCategory === cat.value
-                            ? "bg-gray-700/80 text-white shadow-sm"
-                            : "text-gray-500 hover:text-gray-300 hover:bg-gray-700/30"
+                        key={key}
+                        onClick={() => setActiveMood(isActive ? null : key)}
+                        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium whitespace-nowrap transition-all border ${
+                          isActive
+                            ? "bg-indigo-600 border-indigo-500 text-white shadow-md"
+                            : "bg-gray-800/60 border-gray-700/50 text-gray-400 hover:text-gray-200 hover:border-gray-600"
                         }`}
                       >
-                        {cat.label}
-                        {categoryCounts[cat.value] != null && (
-                          <span className={`text-xs tabular-nums ${recCategory === cat.value ? "text-gray-400" : "text-gray-600"}`}>
-                            {categoryCounts[cat.value]}
-                          </span>
-                        )}
+                        <span>{preset.icon}</span>
+                        <span>{preset.label}</span>
                       </button>
-                    ))}
-                  </div>
-                  <div className="flex items-center gap-2 flex-shrink-0">
-                    {lastRecsRefresh && (
-                      <span className="text-gray-600 text-xs hidden sm:inline">
-                        refreshed {formatRefreshTime(lastRecsRefresh)}
-                      </span>
-                    )}
-                    <button
-                      onClick={refreshRecs}
-                      className="text-gray-500 hover:text-white p-1.5 rounded-lg hover:bg-gray-800/60 transition-all"
-                      title="Refresh recommendations"
-                    >
-                      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                      </svg>
-                    </button>
-                  </div>
+                    );
+                  })}
                 </div>
-                {recsLoading ? (
+
+                {/* Category tabs + refresh */}
+                {!activeMood && (
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="flex gap-1 overflow-x-auto bg-gray-800/40 p-1 rounded-xl">
+                      {REC_CATEGORIES.filter((cat) => cat.value === "all" || !disabledEngines.includes(cat.value)).map((cat) => (
+                        <button
+                          key={cat.value}
+                          onClick={() => setRecCategory(cat.value)}
+                          className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-all whitespace-nowrap flex items-center gap-1.5 ${
+                            recCategory === cat.value
+                              ? "bg-gray-700/80 text-white shadow-sm"
+                              : "text-gray-500 hover:text-gray-300 hover:bg-gray-700/30"
+                          }`}
+                        >
+                          {cat.label}
+                          {categoryCounts[cat.value] != null && (
+                            <span className={`text-xs tabular-nums ${recCategory === cat.value ? "text-gray-400" : "text-gray-600"}`}>
+                              {categoryCounts[cat.value]}
+                            </span>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      {lastRecsRefresh && (
+                        <span className="text-gray-600 text-xs hidden sm:inline">
+                          refreshed {formatRefreshTime(lastRecsRefresh)}
+                        </span>
+                      )}
+                      <button
+                        onClick={refreshRecs}
+                        className="text-gray-500 hover:text-white p-1.5 rounded-lg hover:bg-gray-800/60 transition-all"
+                        title="Refresh recommendations"
+                      >
+                        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Mood results */}
+                {activeMood ? (
+                  moodLoading ? (
+                    <RecommendationSkeleton />
+                  ) : moodError ? (
+                    <div className="text-center py-24">
+                      <div className="w-20 h-20 mx-auto mb-6 rounded-2xl bg-gray-800/50 flex items-center justify-center">
+                        <span className="text-4xl">⚠️</span>
+                      </div>
+                      <p className="text-gray-400 text-lg font-medium">
+                        Failed to load mood picks
+                      </p>
+                      <p className="text-gray-600 text-sm mt-2">{moodError}</p>
+                    </div>
+                  ) : moodGroups.length === 0 ? (
+                    <div className="text-center py-24">
+                      <div className="w-20 h-20 mx-auto mb-6 rounded-2xl bg-gray-800/50 flex items-center justify-center">
+                        <span className="text-4xl">{MOOD_PRESETS[activeMood].icon}</span>
+                      </div>
+                      <p className="text-gray-400 text-lg font-medium">
+                        No results for this mood
+                      </p>
+                      <p className="text-gray-600 text-sm mt-2">
+                        Try adding more movies or select a different mood
+                      </p>
+                    </div>
+                  ) : (
+                    <div>
+                      <p className="text-gray-500 text-xs mb-3">
+                        {MOOD_PRESETS[activeMood].reason} — {moodGroups.flatMap((g) => g.recommendations).length} picks
+                      </p>
+                      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+                        {moodGroups.flatMap((g) => g.recommendations).map((r) => (
+                          <div key={r.tmdb_id} className="relative group/rec">
+                            <MovieCard
+                              title={r.title}
+                              year={r.year}
+                              genre={r.genre}
+                              rating={r.rating}
+                              userRating={null}
+                              posterUrl={r.poster_url}
+                              source="tmdb"
+                              cdaUrl={r.cda_url}
+                              onClick={() => handleRecClick(r)}
+                            />
+                            <div className="absolute bottom-14 right-1 flex flex-col gap-1 opacity-0 group-hover/rec:opacity-100 transition-all duration-200">
+                              <button onClick={() => handleRecAction(r.tmdb_id, "liked", r, true)} className="bg-green-600/90 backdrop-blur-sm text-white rounded-lg w-7 h-7 text-sm flex items-center justify-center hover:bg-green-500 transition-colors" title="Watched &amp; liked">👍</button>
+                              <button onClick={() => handleRecAction(r.tmdb_id, "watched", r, true)} className="bg-gray-600/90 backdrop-blur-sm text-white rounded-lg w-7 h-7 text-sm flex items-center justify-center hover:bg-gray-500 transition-colors" title="Watched">👁</button>
+                              <button onClick={() => handleRecAction(r.tmdb_id, "wishlist", r, true)} className="bg-blue-600/90 backdrop-blur-sm text-white rounded-lg w-7 h-7 text-sm flex items-center justify-center hover:bg-blue-500 transition-colors" title="Add to watchlist">🔖</button>
+                              <button onClick={() => handleRecAction(r.tmdb_id, "disliked", r, true)} className="bg-orange-600/90 backdrop-blur-sm text-white rounded-lg w-7 h-7 text-sm flex items-center justify-center hover:bg-orange-500 transition-colors" title="Watched &amp; disliked">👎</button>
+                              <button onClick={() => handleRecAction(r.tmdb_id, "dismiss", r, true)} className="bg-red-600/90 backdrop-blur-sm text-white rounded-lg w-7 h-7 text-sm flex items-center justify-center hover:bg-red-500 transition-colors" title="Don't show again">✕</button>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )
+                ) : recsLoading ? (
                   <RecommendationSkeleton />
                 ) : recommendations.length === 0 ? (
                   <div className="text-center py-24">

--- a/lib/engines/genre.ts
+++ b/lib/engines/genre.ts
@@ -11,7 +11,7 @@ export async function genreEngine(
   const genreScores = new Map<string, number>();
   for (const movie of ctx.library) {
     if (!movie.genre) continue;
-    const weight = movie.user_rating ?? 5;
+    const weight = (movie.user_rating == null || movie.user_rating === 0) ? 5 : movie.user_rating;
     if (weight < 5) continue; // exclude disliked
     for (const g of movie.genre.split(", ")) {
       const genre = g.trim();

--- a/lib/engines/mood.ts
+++ b/lib/engines/mood.ts
@@ -1,0 +1,63 @@
+import { discoverByMood } from "../tmdb";
+import type { TmdbSearchResult } from "../tmdb";
+import { filterResults, type EngineContext, type RecommendationGroup } from "./index";
+import { MOOD_PRESETS, type MoodKey } from "../mood-presets";
+
+
+export async function moodEngine(
+  ctx: EngineContext,
+  moodKey: MoodKey,
+): Promise<RecommendationGroup[]> {
+  const preset = MOOD_PRESETS[moodKey];
+
+  if (preset.comfortRewatch) {
+    const picks = ctx.library
+      .filter((m) => m.tmdb_id && !ctx.dismissedIds.has(m.tmdb_id))
+      .filter((m) => {
+        if (m.user_rating != null && m.user_rating >= 8) return true;
+        if ((m.user_rating == null || m.user_rating === 0) && m.rating != null && m.rating >= 7) return true;
+        return false;
+      })
+      .sort((a, b) => {
+        const ra = a.user_rating ?? a.rating ?? 0;
+        const rb = b.user_rating ?? b.rating ?? 0;
+        return rb - ra;
+      })
+      .slice(0, 30)
+      .map(
+        (m): TmdbSearchResult => ({
+          title: m.title,
+          year: m.year,
+          genre: m.genre || "",
+          rating: m.rating ?? 0,
+          poster_url: m.poster_url,
+          tmdb_id: m.tmdb_id!,
+          imdb_id: m.imdb_id,
+          pl_title: m.pl_title,
+        }),
+      );
+
+    if (picks.length === 0) return [];
+    return [{ reason: preset.reason, type: "mood", recommendations: picks }];
+  }
+
+  const results = await discoverByMood({
+    genreIds: preset.genreIds,
+    minRating: preset.minRating,
+    minVotes: preset.minVotes,
+    maxRuntime: preset.maxRuntime,
+    languages: preset.languages,
+    pages: 3,
+  });
+
+  const filtered = filterResults(results, ctx);
+  if (filtered.length === 0) return [];
+
+  return [
+    {
+      reason: preset.reason,
+      type: "mood",
+      recommendations: filtered.slice(0, 30),
+    },
+  ];
+}

--- a/lib/mood-presets.ts
+++ b/lib/mood-presets.ts
@@ -1,0 +1,89 @@
+export type MoodKey =
+  | "light_funny"
+  | "mind_bender"
+  | "comfort_rewatch"
+  | "date_night"
+  | "dark_heavy"
+  | "short"
+  | "foreign"
+  | "feel_good";
+
+export interface MoodPreset {
+  label: string;
+  icon: string;
+  reason: string;
+  genreIds?: number[];
+  minRating?: number;
+  minVotes?: number;
+  maxRuntime?: number;
+  languages?: string[];
+  comfortRewatch?: boolean;
+}
+
+export const MOOD_PRESETS: Record<MoodKey, MoodPreset> = {
+  light_funny: {
+    label: "Light & Funny",
+    icon: "😄",
+    reason: "Light & funny tonight",
+    genreIds: [35, 10751],
+    minRating: 6.5,
+    minVotes: 200,
+  },
+  mind_bender: {
+    label: "Mind-bender",
+    icon: "🤯",
+    reason: "Something to mess with your head",
+    genreIds: [878, 9648, 53],
+    minRating: 7.5,
+    minVotes: 300,
+  },
+  comfort_rewatch: {
+    label: "Comfort Rewatch",
+    icon: "🛋️",
+    reason: "Comfort picks from your library",
+    comfortRewatch: true,
+  },
+  date_night: {
+    label: "Date Night",
+    icon: "🌹",
+    reason: "Perfect for date night",
+    genreIds: [10749, 35],
+    minRating: 7,
+    minVotes: 300,
+  },
+  dark_heavy: {
+    label: "Dark & Heavy",
+    icon: "🌑",
+    reason: "Dark and intense",
+    genreIds: [18, 80, 10752],
+    minRating: 7.5,
+    minVotes: 500,
+  },
+  short: {
+    label: "Short (<100min)",
+    icon: "⚡",
+    reason: "Short films under 100 minutes",
+    genreIds: [35, 28, 16],
+    minRating: 7,
+    minVotes: 200,
+    maxRuntime: 100,
+  },
+  foreign: {
+    label: "Foreign",
+    icon: "🌍",
+    reason: "World cinema picks",
+    languages: ["fr", "ja", "ko", "es", "it"],
+    minRating: 7.5,
+    minVotes: 300,
+  },
+  feel_good: {
+    label: "Feel-good",
+    icon: "🌟",
+    reason: "Movies that leave you smiling",
+    genreIds: [16, 10751, 35],
+    minRating: 7,
+    minVotes: 300,
+  },
+};
+
+export const MOOD_KEYS = Object.keys(MOOD_PRESETS) as MoodKey[];

--- a/lib/tmdb.ts
+++ b/lib/tmdb.ts
@@ -339,6 +339,59 @@ export async function discoverRandom(): Promise<TmdbSearchResult[]> {
   return all;
 }
 
+export interface MoodDiscoverParams {
+  genreIds?: number[];
+  minRating?: number;
+  minVotes?: number;
+  maxRuntime?: number;
+  languages?: string[];
+  pages?: number;
+}
+
+export async function discoverByMood(
+  params: MoodDiscoverParams,
+): Promise<TmdbSearchResult[]> {
+  const apiKey = getApiKey();
+  const {
+    genreIds,
+    minRating = 6.5,
+    minVotes = 200,
+    maxRuntime,
+    languages,
+    pages = 3,
+  } = params;
+
+  function buildUrl(page: number, lang?: string): string {
+    let url = `${TMDB_BASE}/discover/movie?sort_by=vote_average.desc&vote_count.gte=${minVotes}&vote_average.gte=${minRating}&language=en-US&page=${page}`;
+    if (genreIds?.length) url += `&with_genres=${genreIds.join(",")}`;
+    if (maxRuntime) url += `&with_runtime.lte=${maxRuntime}`;
+    if (lang) url += `&with_original_language=${lang}`;
+    return url;
+  }
+
+  function shuffle<T>(arr: T[]): T[] {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  if (languages?.length) {
+    const all: TmdbSearchResult[] = [];
+    for (const lang of languages) {
+      const urls = Array.from({ length: pages }, (_, i) =>
+        buildUrl(i + 1, lang),
+      );
+      all.push(...(await fetchDiscoverPages(urls, apiKey)));
+    }
+    return shuffle(all);
+  }
+
+  const urls = Array.from({ length: pages }, (_, i) => buildUrl(i + 1));
+  return shuffle(await fetchDiscoverPages(urls, apiKey));
+}
+
 export async function getMovieCredits(
   tmdbId: number,
 ): Promise<{ directors: TmdbCredit[]; cast: TmdbCredit[] }> {


### PR DESCRIPTION
Closes #48                            
                                                                                                                                                  
  - **feat(recommendations): add mood recommendation engine**                                                                                     
  - **test(mood): add discoverByMood and moodEngine config constraint tests**                                                                     
  - **fix(security): patch path traversal, add input validation, improve error logging**                                                          
  - **fix(genre): treat 0 rating as unrated**                                                                                                     