### PR TITLE
fix: Align CI on Node 22 so checks match the deployed runtime

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
Closes #96

Implemented via TamTam from issue [#96](https://github.com/3h4x/film-pick/issues/96).