### PR TITLE
fix: Let library searches expand to TMDb results on demand

### DIFF
--- a/__tests__/search-utils.test.ts
+++ b/__tests__/search-utils.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { getSearchMatches, shouldAutoSearchTmdb } from "@/lib/search";
+import type { Movie } from "@/lib/types";
+
+function makeMovie(overrides: Partial<Movie>): Movie {
+  return {
+    id: overrides.id ?? 1,
+    title: overrides.title ?? "Inception",
+    year: overrides.year ?? 2010,
+    genre: overrides.genre ?? "Sci-Fi",
+    director: overrides.director ?? null,
+    writer: overrides.writer ?? null,
+    actors: overrides.actors ?? null,
+    rating: overrides.rating ?? 8.8,
+    user_rating: overrides.user_rating ?? null,
+    poster_url: overrides.poster_url ?? null,
+    source: overrides.source ?? "tmdb",
+    type: overrides.type ?? "movie",
+    tmdb_id: overrides.tmdb_id ?? 100,
+    rated_at: overrides.rated_at ?? null,
+    created_at: overrides.created_at ?? "2026-01-01T00:00:00.000Z",
+    filmweb_url: overrides.filmweb_url ?? null,
+    cda_url: overrides.cda_url ?? null,
+    pl_title: overrides.pl_title ?? null,
+    wishlist: overrides.wishlist ?? 0,
+    file_path: overrides.file_path ?? null,
+  };
+}
+
+describe("search utils", () => {
+  it("splits library and watchlist matches for a shared query", () => {
+    const movies = [
+      makeMovie({ id: 1, title: "Alien", wishlist: 0 }),
+      makeMovie({ id: 2, title: "Alien: Covenant", wishlist: 1 }),
+    ];
+
+    const { libraryMatches, wishlistMatches } = getSearchMatches(
+      movies,
+      "alien",
+    );
+
+    expect(libraryMatches.map((movie) => movie.id)).toEqual([1]);
+    expect(wishlistMatches.map((movie) => movie.id)).toEqual([2]);
+  });
+
+  it("does not auto-search TMDb when the query already matches local titles", () => {
+    const movies = [
+      makeMovie({ id: 1, title: "Alien", wishlist: 0 }),
+      makeMovie({ id: 2, title: "Aliens", wishlist: 1 }),
+    ];
+
+    expect(shouldAutoSearchTmdb(movies, "alien")).toBe(false);
+  });
+
+  it("auto-searches TMDb when the query has no local matches", () => {
+    const movies = [
+      makeMovie({ id: 1, title: "Alien", wishlist: 0 }),
+      makeMovie({ id: 2, title: "Aliens", wishlist: 1 }),
+    ];
+
+    expect(shouldAutoSearchTmdb(movies, "blade runner")).toBe(true);
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -222,9 +222,11 @@ export default function Home() {
           <SearchView searchQuery={searchQuery} movies={movies}
             tmdbResults={search.tmdbResults} tmdbLoading={search.tmdbLoading}
             tmdbAdded={search.tmdbAdded} tmdbError={search.tmdbError}
+            tmdbSearched={search.tmdbSearched}
             onMovieClick={setSelectedMovie}
             onClear={() => { setSearchQuery(""); setActiveTab("library"); }}
             onGoToConfig={() => { setSearchQuery(""); setActiveTab("config"); }}
+            onSearchTmdb={() => search.handleNavSearch(searchQuery, { forceTmdb: true })}
             onAddToLibrary={async (r) => { await search.handleAddMovie(r, false); search.setTmdbAdded((prev) => new Set(prev).add(r.tmdb_id)); }}
             onAddToWatchlist={async (r) => { await search.handleAddMovie(r, true); search.setTmdbAdded((prev) => new Set(prev).add(r.tmdb_id)); }}
           />
@@ -232,7 +234,7 @@ export default function Home() {
         {activeTab === "library" && (
           <LibraryView library={library} onMovieClick={setSelectedMovie} onImport={() => setImportOpen(true)}
             onOpenSearch={() => setSearchOpen(true)}
-            onSearchInTMDb={(q) => { setActiveTab("search"); search.handleNavSearch(q); }}
+            onSearchInTMDb={(q) => { setActiveTab("search"); search.handleNavSearch(q, { forceTmdb: true }); }}
           />
         )}
         {activeTab === "recommendations" && (

--- a/components/views/SearchView.tsx
+++ b/components/views/SearchView.tsx
@@ -1,5 +1,6 @@
 "use client";
 import MovieCard from "@/components/MovieCard";
+import { getSearchMatches } from "@/lib/search";
 import type { Movie } from "@/lib/types";
 import type { TmdbSearchResult } from "@/lib/tmdb";
 
@@ -10,9 +11,11 @@ interface SearchViewProps {
   tmdbLoading: boolean;
   tmdbAdded: Set<number>;
   tmdbError: string | null;
+  tmdbSearched: boolean;
   onMovieClick: (movie: Movie) => void;
   onClear: () => void;
   onGoToConfig: () => void;
+  onSearchTmdb: () => Promise<void>;
   onAddToLibrary: (r: TmdbSearchResult) => Promise<void>;
   onAddToWatchlist: (r: TmdbSearchResult) => Promise<void>;
 }
@@ -24,32 +27,18 @@ export default function SearchView({
   tmdbLoading,
   tmdbAdded,
   tmdbError,
+  tmdbSearched,
   onMovieClick,
   onClear,
   onGoToConfig,
+  onSearchTmdb,
   onAddToLibrary,
   onAddToWatchlist,
 }: SearchViewProps) {
-  const q = searchQuery.toLowerCase();
-  const libraryMatches = movies
-    .filter(
-      (m) =>
-        (m.source !== "recommendation" ||
-          (m.user_rating != null && (m.user_rating as number) > 0)) &&
-        !m.wishlist,
-    )
-    .filter(
-      (m) =>
-        m.title.toLowerCase().includes(q) ||
-        m.pl_title?.toLowerCase().includes(q),
-    );
-  const wishlistMatches = movies
-    .filter((m) => m.wishlist === 1)
-    .filter(
-      (m) =>
-        m.title.toLowerCase().includes(q) ||
-        m.pl_title?.toLowerCase().includes(q),
-    );
+  const { libraryMatches, wishlistMatches } = getSearchMatches(
+    movies,
+    searchQuery,
+  );
   const tmdbOnly = tmdbResults.filter(
     (r) => !movies.some((m) => m.tmdb_id === r.tmdb_id),
   );
@@ -86,6 +75,21 @@ export default function SearchView({
             className="mt-5 px-5 py-2 rounded-lg bg-indigo-600 text-white text-sm hover:bg-indigo-500 transition-colors"
           >
             Go to Config
+          </button>
+        </div>
+      ) : tmdbError === "error" ? (
+        <div className="text-center py-24">
+          <p className="text-gray-400 text-lg font-medium">
+            TMDb search failed
+          </p>
+          <p className="text-gray-600 text-sm mt-2">
+            Try again in a moment
+          </p>
+          <button
+            onClick={onSearchTmdb}
+            className="mt-5 px-5 py-2 rounded-lg bg-indigo-600 text-white text-sm hover:bg-indigo-500 transition-colors"
+          >
+            Search TMDb
           </button>
         </div>
       ) : (
@@ -136,7 +140,27 @@ export default function SearchView({
             </div>
           )}
 
-          {tmdbOnly.length > 0 ? (
+          {!tmdbSearched ? (
+            <div className="rounded-2xl border border-white/8 bg-white/[0.03] p-5 sm:p-6">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-widest text-gray-500">
+                    Expand Search
+                  </p>
+                  <p className="mt-2 text-sm text-gray-400">
+                    Search TMDb for more matches beyond your library and
+                    watchlist.
+                  </p>
+                </div>
+                <button
+                  onClick={onSearchTmdb}
+                  className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-500"
+                >
+                  Search TMDb
+                </button>
+              </div>
+            </div>
+          ) : tmdbOnly.length > 0 ? (
             <div>
               <p className="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-3">
                 From TMDb
@@ -183,16 +207,21 @@ export default function SearchView({
                 })}
               </div>
             </div>
-          ) : libraryMatches.length === 0 ? (
-            <div className="text-center py-16">
-              <p className="text-gray-400 text-lg font-medium">
-                No results for &ldquo;{searchQuery}&rdquo;
+          ) : (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-3">
+                From TMDb
               </p>
-              <p className="text-gray-600 text-sm mt-2">
-                Try a different title or check spelling
-              </p>
+              <div className="rounded-2xl border border-white/8 bg-white/[0.03] px-5 py-8 text-center">
+                <p className="text-gray-400 text-lg font-medium">
+                  No TMDb results for &ldquo;{searchQuery}&rdquo;
+                </p>
+                <p className="text-gray-600 text-sm mt-2">
+                  Try a different title or check spelling
+                </p>
+              </div>
             </div>
-          ) : null}
+          )}
         </div>
       )}
     </div>

--- a/lib/hooks/useSearch.ts
+++ b/lib/hooks/useSearch.ts
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { shouldAutoSearchTmdb } from "@/lib/search";
 import type { Movie } from "@/lib/types";
 import type { TmdbSearchResult } from "@/lib/tmdb";
 import { cleanTitle } from "@/lib/utils";
@@ -26,6 +27,30 @@ export function useSearch({
   const [tmdbLoading, setTmdbLoading] = useState(false);
   const [tmdbAdded, setTmdbAdded] = useState<Set<number>>(new Set());
   const [tmdbError, setTmdbError] = useState<string | null>(null);
+  const [tmdbSearched, setTmdbSearched] = useState(false);
+
+  async function runTmdbSearch(query: string) {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) return;
+
+    setTmdbLoading(true);
+    setTmdbError(null);
+    setTmdbSearched(true);
+
+    try {
+      const res = await fetch(`/api/search?q=${encodeURIComponent(trimmedQuery)}`);
+      if (res.ok) {
+        setTmdbResults(await res.json());
+      } else {
+        const body = await res.json().catch(() => ({}));
+        setTmdbError(body.error === "no_api_key" ? "no_api_key" : "error");
+      }
+    } catch {
+      setTmdbError("error");
+    } finally {
+      setTmdbLoading(false);
+    }
+  }
 
   async function handleAddMovie(
     searchResult: TmdbSearchResult,
@@ -191,46 +216,22 @@ export function useSearch({
     );
   }
 
-  async function handleNavSearch(query: string) {
+  async function handleNavSearch(
+    query: string,
+    options?: { forceTmdb?: boolean },
+  ) {
     setTmdbResults([]);
     setTmdbError(null);
     setTmdbAdded(new Set());
+    setTmdbSearched(false);
 
-    const q = query.trim().toLowerCase();
-    const libraryMatches = movies
-      .filter(
-        (m) =>
-          (m.source !== "recommendation" ||
-            (m.user_rating != null && (m.user_rating as number) > 0)) &&
-          !m.wishlist,
-      )
-      .filter(
-        (m) =>
-          m.title.toLowerCase().includes(q) ||
-          m.pl_title?.toLowerCase().includes(q),
-      );
-    const wishlistMatches = movies
-      .filter((m) => m.wishlist === 1)
-      .filter(
-        (m) =>
-          m.title.toLowerCase().includes(q) ||
-          m.pl_title?.toLowerCase().includes(q),
-      );
+    if (options?.forceTmdb) {
+      await runTmdbSearch(query);
+      return;
+    }
 
-    if (libraryMatches.length === 0 && wishlistMatches.length === 0) {
-      setTmdbLoading(true);
-      const res = await fetch(
-        `/api/search?q=${encodeURIComponent(query.trim())}`,
-      );
-      if (res.ok) {
-        setTmdbResults(await res.json());
-      } else {
-        const body = await res.json().catch(() => ({}));
-        setTmdbError(
-          body.error === "no_api_key" ? "no_api_key" : "error",
-        );
-      }
-      setTmdbLoading(false);
+    if (shouldAutoSearchTmdb(movies, query)) {
+      await runTmdbSearch(query);
     }
   }
 
@@ -245,6 +246,8 @@ export function useSearch({
     setTmdbAdded,
     tmdbError,
     setTmdbError,
+    tmdbSearched,
+    runTmdbSearch,
     handleAddMovie,
     handleNavSearch,
   };

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,41 @@
+import type { Movie } from "@/lib/types";
+
+export interface SearchMatches {
+  libraryMatches: Movie[];
+  wishlistMatches: Movie[];
+}
+
+export function getSearchMatches(
+  movies: Movie[],
+  rawQuery: string,
+): SearchMatches {
+  const query = rawQuery.trim().toLowerCase();
+
+  if (!query) {
+    return { libraryMatches: [], wishlistMatches: [] };
+  }
+
+  const matchesQuery = (movie: Movie) =>
+    movie.title.toLowerCase().includes(query) ||
+    movie.pl_title?.toLowerCase().includes(query);
+
+  const libraryMatches = movies
+    .filter(
+      (movie) =>
+        (movie.source !== "recommendation" ||
+          (movie.user_rating != null && movie.user_rating > 0)) &&
+        !movie.wishlist,
+    )
+    .filter(matchesQuery);
+
+  const wishlistMatches = movies
+    .filter((movie) => movie.wishlist === 1)
+    .filter(matchesQuery);
+
+  return { libraryMatches, wishlistMatches };
+}
+
+export function shouldAutoSearchTmdb(movies: Movie[], rawQuery: string) {
+  const { libraryMatches, wishlistMatches } = getSearchMatches(movies, rawQuery);
+  return libraryMatches.length === 0 && wishlistMatches.length === 0;
+}


### PR DESCRIPTION
Closes #101

Implemented issue #101.

The search flow now stays local-first on Enter, but if the query already matches your library or watchlist, the Search view shows a visible `Search TMDb` action and can expand the same query on demand. That explicit path reuses the existing `/api/search` route and the current add-to-library/watchlist handlers. I also added a dedicated `tmdbSearched` state so the UI can distinguish “not searched yet” from “searched and got no new TMDb results.”

The branching logic is now centralized in [lib/search.ts](/Users/3h4x/workspace/filmpick/lib/search.ts), reused by [lib/hooks/useSearch.ts](/Users/3h4x/workspace/filmpick/lib/hooks/useSearch.ts), [components/views/SearchView.tsx](/Users/3h4x/workspace/filmpick/components/views/SearchView.tsx), and wired through [app/page.ts…

---
Implemented via TamTam from issue [#101](https://github.com/3h4x/film-pick/issues/101).