### PR TITLE
fix: Preserve ratings when sync removes missing files

### DIFF
--- a/__tests__/db.test.ts
+++ b/__tests__/db.test.ts
@@ -292,19 +292,24 @@ describe("insertMovie deduplication", () => {
   };
 
   it("returns existing id without overwriting file_path when tmdb_id matches and entry already has a file", () => {
-    const id1 = insertMovie(db, { ...base, file_path: "/movies/gits-original.mkv" });
+    const id1 = insertMovie(db, {
+      ...base,
+      file_path: "/movies/gits-original.mkv",
+      video_metadata: '{"duration":8000}',
+    });
     const id2 = insertMovie(db, { ...base, file_path: "/movies/gits-remaster.mkv" });
 
     // Should point to the same DB entry
     expect(id2).toBe(id1);
 
     // Primary file_path must NOT have been overwritten
-    const row = db.prepare("SELECT file_path, extra_files FROM movies WHERE id = ?").get(id1) as { file_path: string; extra_files: string };
+    const row = db.prepare("SELECT file_path, extra_files, video_metadata FROM movies WHERE id = ?").get(id1) as { file_path: string; extra_files: string; video_metadata: string | null };
     expect(row.file_path).toBe("/movies/gits-original.mkv");
 
     // Second path goes to extra_files
     const extras = JSON.parse(row.extra_files);
     expect(extras).toContain("/movies/gits-remaster.mkv");
+    expect(row.video_metadata).toBeNull();
   });
 
   it("does not create duplicate entries — same tmdb_id returns single row", () => {
@@ -335,15 +340,20 @@ describe("insertMovie deduplication", () => {
 
   it("deduplicates by title+year when no tmdb_id, adds extra_files instead of overwriting", () => {
     const noTmdb = { ...base, tmdb_id: null };
-    const id1 = insertMovie(db, { ...noTmdb, file_path: "/movies/gits-a.mkv" });
+    const id1 = insertMovie(db, {
+      ...noTmdb,
+      file_path: "/movies/gits-a.mkv",
+      video_metadata: '{"duration":8000}',
+    });
     const id2 = insertMovie(db, { ...noTmdb, file_path: "/movies/gits-b.mkv" });
 
     expect(id2).toBe(id1);
 
-    const row = db.prepare("SELECT file_path, extra_files FROM movies WHERE id = ?").get(id1) as { file_path: string; extra_files: string };
+    const row = db.prepare("SELECT file_path, extra_files, video_metadata FROM movies WHERE id = ?").get(id1) as { file_path: string; extra_files: string; video_metadata: string | null };
     expect(row.file_path).toBe("/movies/gits-a.mkv");
     const extras = JSON.parse(row.extra_files);
     expect(extras).toContain("/movies/gits-b.mkv");
+    expect(row.video_metadata).toBeNull();
   });
 
   it("enriches missing genre when tmdb_id match finds entry without genre", () => {

--- a/__tests__/sync-api.test.ts
+++ b/__tests__/sync-api.test.ts
@@ -81,7 +81,7 @@ describe("sync API route", () => {
     const complete = events.find((e) => e.type === "complete");
     expect(complete).toBeDefined();
     expect(complete!.added).toBe(0);
-    expect(complete!.removed).toBe(0);
+    expect(complete!.detached).toBe(0);
     expect(complete!.total).toBe(0);
   });
 
@@ -209,20 +209,27 @@ describe("sync API route", () => {
     expect(complete!.failed).toBe(1);
   });
 
-  it("removes movies whose file_path no longer exists on disk", async () => {
+  it("detaches missing files while preserving ratings and metadata", async () => {
     setSetting(db as unknown as ReturnType<typeof getDb>, 'library_path', '/movies');
     insertMovie(db as unknown as ReturnType<typeof getDb>, {
       title: "Old Film",
       year: 1999,
-      genre: null,
+      genre: "Drama",
       director: null,
-      rating: null,
+      rating: 7.4,
       poster_url: null,
-      source: "local",
+      source: "filmweb",
       imdb_id: null,
-      tmdb_id: null,
+      tmdb_id: 1234,
       type: "movie",
       file_path: "/movies/OldFilm.1999.mkv",
+      user_rating: 9,
+      wishlist: 1,
+      filmweb_id: 5678,
+      filmweb_url: "https://filmweb.example/old-film",
+      cda_url: "https://cda.example/old-film",
+      pl_title: "Stary Film",
+      description: "Preserve me",
     });
 
     // Scanner finds no files — the old file is gone
@@ -232,10 +239,41 @@ describe("sync API route", () => {
     const events = await readNDJSON(res);
 
     const complete = events.find((e) => e.type === "complete");
-    expect(complete!.removed).toBe(1);
+    expect(complete!.detached).toBe(1);
 
-    const movies = db.prepare("SELECT * FROM movies").all();
-    expect(movies).toHaveLength(0);
+    const movies = db.prepare(
+      "SELECT title, file_path, extra_files, video_metadata, user_rating, rating, wishlist, tmdb_id, filmweb_id, filmweb_url, cda_url, pl_title, description FROM movies",
+    ).all() as Array<{
+      title: string;
+      file_path: string | null;
+      extra_files: string | null;
+      video_metadata: string | null;
+      user_rating: number | null;
+      rating: number | null;
+      wishlist: number;
+      tmdb_id: number | null;
+      filmweb_id: number | null;
+      filmweb_url: string | null;
+      cda_url: string | null;
+      pl_title: string | null;
+      description: string | null;
+    }>;
+    expect(movies).toHaveLength(1);
+    expect(movies[0]).toMatchObject({
+      title: "Old Film",
+      file_path: null,
+      extra_files: null,
+      video_metadata: null,
+      user_rating: 9,
+      rating: 7.4,
+      wishlist: 1,
+      tmdb_id: 1234,
+      filmweb_id: 5678,
+      filmweb_url: "https://filmweb.example/old-film",
+      cda_url: "https://cda.example/old-film",
+      pl_title: "Stary Film",
+      description: "Preserve me",
+    });
   });
 
   it("does not remove movies already in extra_files on rescan", async () => {
@@ -261,7 +299,118 @@ describe("sync API route", () => {
 
     const complete = events.find((e) => e.type === "complete");
     // Primary file exists — movie should NOT be removed
-    expect(complete!.removed).toBe(0);
+    expect(complete!.detached).toBe(0);
+  });
+
+  it("prunes missing extra files and invalidates cached video metadata", async () => {
+    setSetting(db as unknown as ReturnType<typeof getDb>, 'library_path', '/movies');
+    db.prepare(
+      "INSERT INTO movies (title, year, source, type, file_path, extra_files, video_metadata) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "Matrix",
+      1999,
+      "tmdb",
+      "movie",
+      "/movies/Matrix.mkv",
+      JSON.stringify(["/movies/Matrix.alt.mkv", "/movies/Matrix.deleted.mkv"]),
+      JSON.stringify({
+        duration: 8000,
+        extra_files: [
+          { path: "/movies/Matrix.alt.mkv", duration: 8001 },
+          { path: "/movies/Matrix.deleted.mkv", duration: 8002 },
+        ],
+      }),
+    );
+
+    vi.mocked(scanDirectoryGenerator).mockReturnValue(
+      (function* () {
+        yield {
+          filename: "Matrix.mkv",
+          filePath: "/movies/Matrix.mkv",
+          parsedTitle: "Matrix",
+          parsedYear: 1999,
+        };
+        yield {
+          filename: "Matrix.alt.mkv",
+          filePath: "/movies/Matrix.alt.mkv",
+          parsedTitle: "Matrix",
+          parsedYear: 1999,
+        };
+      })(),
+    );
+
+    const res = await POST();
+    const events = await readNDJSON(res);
+
+    const complete = events.find((e) => e.type === "complete");
+    expect(complete!.detached).toBe(0);
+
+    const row = db.prepare(
+      "SELECT extra_files, video_metadata FROM movies",
+    ).get() as {
+      extra_files: string | null;
+      video_metadata: string | null;
+    };
+    expect(JSON.parse(row.extra_files ?? "[]")).toEqual([
+      "/movies/Matrix.alt.mkv",
+    ]);
+    expect(row.video_metadata).toBeNull();
+  });
+
+  it("promotes an existing extra file when the primary path is missing", async () => {
+    setSetting(db as unknown as ReturnType<typeof getDb>, 'library_path', '/movies');
+    db.prepare(
+      "INSERT INTO movies (title, year, source, type, file_path, extra_files, video_metadata) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "Matrix",
+      1999,
+      "tmdb",
+      "movie",
+      "/movies/Matrix.mkv",
+      JSON.stringify(["/movies/Matrix.alt.mkv"]),
+      '{"duration":8000}',
+    );
+
+    vi.mocked(scanDirectoryGenerator).mockImplementation(
+      () =>
+        (function* () {
+          yield {
+            filename: "Matrix.alt.mkv",
+            filePath: "/movies/Matrix.alt.mkv",
+            parsedTitle: "Matrix",
+            parsedYear: 1999,
+          };
+        })(),
+    );
+
+    const firstRes = await POST();
+    const firstEvents = await readNDJSON(firstRes);
+    const firstComplete = firstEvents.find((e) => e.type === "complete");
+    expect(firstComplete!.detached).toBe(0);
+
+    const promoted = db.prepare(
+      "SELECT file_path, extra_files, video_metadata FROM movies",
+    ).all() as Array<{
+      file_path: string | null;
+      extra_files: string | null;
+      video_metadata: string | null;
+    }>;
+    expect(promoted).toHaveLength(1);
+    expect(promoted[0]).toMatchObject({
+      file_path: "/movies/Matrix.alt.mkv",
+      extra_files: null,
+      video_metadata: null,
+    });
+
+    const secondRes = await POST();
+    const secondEvents = await readNDJSON(secondRes);
+    const secondComplete = secondEvents.find((e) => e.type === "complete");
+    expect(secondComplete!.detached).toBe(0);
+    expect(secondComplete!.added).toBe(0);
+    expect(searchTmdb).not.toHaveBeenCalled();
+
+    const movies = db.prepare("SELECT id FROM movies").all();
+    expect(movies).toHaveLength(1);
   });
 
   it("links to existing pathless row with year=NULL (year IS ? handles NULL)", async () => {

--- a/app/api/movies/[id]/standardize/route.ts
+++ b/app/api/movies/[id]/standardize/route.ts
@@ -201,7 +201,7 @@ export async function POST(
           // Otherwise, we merge the conflict into the current one and update the current one's path
           mergeMovies(conflict.id, movieId);
           db.prepare(
-            "UPDATE movies SET file_path = ?, title = ?, year = ? WHERE id = ?",
+            "UPDATE movies SET file_path = ?, title = ?, year = ?, video_metadata = NULL WHERE id = ?",
           ).run(newPath, finalTitle, finalYear, movieId);
           return Response.json({
             ok: true,
@@ -214,7 +214,7 @@ export async function POST(
       }
 
       db.prepare(
-        "UPDATE movies SET file_path = ?, title = ?, year = ? WHERE id = ?",
+        "UPDATE movies SET file_path = ?, title = ?, year = ?, video_metadata = NULL WHERE id = ?",
       ).run(newPath, finalTitle, finalYear, movieId);
       return Response.json({
         ok: true,
@@ -383,7 +383,7 @@ export async function POST(
     // 6. Update DB
     console.log(`- Updating DB record: id=${movieId}`);
     db.prepare(
-      "UPDATE movies SET file_path = ?, title = ?, year = ?, extra_files = ? WHERE id = ?",
+      "UPDATE movies SET file_path = ?, title = ?, year = ?, extra_files = ?, video_metadata = NULL WHERE id = ?",
     ).run(newPath, finalTitle, finalYear, updatedExtraFiles, movieId);
 
     // 6. Delete old directory — movie and subtitles have been moved, remaining contents are trash

--- a/app/api/movies/merge/route.ts
+++ b/app/api/movies/merge/route.ts
@@ -110,6 +110,13 @@ export async function POST(request: NextRequest) {
     }
   }
 
+  if (
+    ("file_path" in updates || "extra_files" in updates) &&
+    existingCols.has("video_metadata")
+  ) {
+    updates.video_metadata = null;
+  }
+
   try {
     const updateKeys = Object.keys(updates);
     const updateParams = Object.values(updates);

--- a/app/api/sync/route.ts
+++ b/app/api/sync/route.ts
@@ -17,6 +17,17 @@ interface PathlessRow {
   tmdb_id: number | null;
 }
 
+function parseExtraFiles(extraFiles: string | null): string[] {
+  if (!extraFiles) return [];
+  try {
+    const parsed = JSON.parse(extraFiles) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((path): path is string => typeof path === "string");
+  } catch {
+    return [];
+  }
+}
+
 // Try to attach a scanned file to an existing pathless DB row before
 // inserting a new one. Returns true if a row was linked.
 //
@@ -34,7 +45,7 @@ function linkToExistingPathlessRow(
 ): boolean {
   const link = (id: number) => {
     db.prepare(
-      "UPDATE movies SET file_path = ?, created_at = CURRENT_TIMESTAMP WHERE id = ?",
+      "UPDATE movies SET file_path = ?, video_metadata = NULL, created_at = CURRENT_TIMESTAMP WHERE id = ?",
     ).run(file.filePath, id);
   };
 
@@ -128,12 +139,7 @@ export async function POST() {
         .all() as { file_path: string; extra_files: string | null }[];
       for (const m of moviesWithPaths) {
         knownPaths.add(m.file_path);
-        if (m.extra_files) {
-          try {
-            const extras = JSON.parse(m.extra_files) as string[];
-            for (const e of extras) knownPaths.add(e);
-          } catch {}
-        }
+        for (const e of parseExtraFiles(m.extra_files)) knownPaths.add(e);
       }
 
       // Separate new files from existing
@@ -240,27 +246,54 @@ export async function POST() {
         }
       }
 
-      // Phase 3: Cleanup — remove movies whose files no longer exist.
-      // Query DB fresh (after Phase 2 updates) so we don't delete movies whose
+      // Phase 3: Cleanup — detach files that no longer exist from their movie rows.
+      // Query DB fresh (after Phase 2 updates) so we don't detach movies whose
       // file_path was just updated in Phase 2 from an old/wrong path.
-      let removed = 0;
+      let detached = 0;
       const currentMovies = db
         .prepare(
-          "SELECT id, file_path FROM movies WHERE file_path IS NOT NULL AND file_path != ''",
+          "SELECT id, file_path, extra_files FROM movies WHERE file_path IS NOT NULL AND file_path != ''",
         )
-        .all() as { id: number; file_path: string }[];
+        .all() as { id: number; file_path: string; extra_files: string | null }[];
       for (const movie of currentMovies) {
-        if (!filePathSet.has(movie.file_path)) {
-          db.prepare("DELETE FROM movies WHERE id = ?").run(movie.id);
-          removed++;
+        const existingExtras = parseExtraFiles(movie.extra_files).filter(
+          (extraPath) => filePathSet.has(extraPath),
+        );
+
+        if (filePathSet.has(movie.file_path)) {
+          const nextExtraFiles =
+            existingExtras.length > 0 ? JSON.stringify(existingExtras) : null;
+          if (nextExtraFiles !== movie.extra_files) {
+            db.prepare(
+              "UPDATE movies SET extra_files = ?, video_metadata = NULL WHERE id = ?",
+            ).run(nextExtraFiles, movie.id);
+          }
+          continue;
         }
+
+        if (existingExtras.length > 0) {
+          const [promotedPath, ...remainingExtras] = existingExtras;
+          db.prepare(
+            "UPDATE movies SET file_path = ?, extra_files = ?, video_metadata = NULL WHERE id = ?",
+          ).run(
+            promotedPath,
+            remainingExtras.length > 0 ? JSON.stringify(remainingExtras) : null,
+            movie.id,
+          );
+          continue;
+        }
+
+        db.prepare(
+          "UPDATE movies SET file_path = NULL, extra_files = NULL, video_metadata = NULL WHERE id = ?",
+        ).run(movie.id);
+        detached++;
       }
 
       sendUpdate({
         type: "complete",
         added,
         linked,
-        removed,
+        detached,
         unchanged,
         failed,
         total: allFiles.length,

--- a/components/SyncModal.tsx
+++ b/components/SyncModal.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 interface SyncResult {
   added: number;
   linked: number;
-  removed: number;
+  detached: number;
   unchanged: number;
   failed: number;
   total: number;
@@ -147,7 +147,8 @@ export default function SyncModal({
         </div>
 
         <p className="text-gray-400 text-sm mb-6">
-          Re-scan your library folder to add new files and remove deleted ones.
+          Re-scan your library folder to add new files and detach entries whose
+          files are missing.
         </p>
 
         {!loading && !result && (
@@ -243,9 +244,9 @@ export default function SyncModal({
                 </span>
               </div>
               <div className="flex flex-col">
-                <span className="text-gray-500 text-xs">Removed</span>
+                <span className="text-gray-500 text-xs">Detached</span>
                 <span className="text-red-400 font-mono text-lg">
-                  {result.removed}
+                  {result.detached}
                 </span>
               </div>
               <div className="flex flex-col">

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -21,7 +21,7 @@ export interface Movie {
   // Columns added by filmweb import and other optional migrations
   user_rating?: number | null;
   pl_title?: string | null;
-  filmweb_id?: string | null;
+  filmweb_id?: number | null;
   filmweb_url?: string | null;
   rated_at?: string | null;
   wishlist?: number | null;
@@ -45,6 +45,15 @@ export interface MovieInput {
   type: string;
   file_path?: string | null;
   extra_files?: string | null;
+  user_rating?: number | null;
+  pl_title?: string | null;
+  filmweb_id?: number | null;
+  filmweb_url?: string | null;
+  rated_at?: string | null;
+  wishlist?: number | null;
+  description?: string | null;
+  cda_url?: string | null;
+  video_metadata?: string | null;
 }
 
 const DB_PATH = path.join(process.cwd(), "data", "movies.db");
@@ -247,7 +256,22 @@ export function getDb(): Database.Database {
 function enrichMissingMetadata(
   db: Database.Database,
   id: number,
-  existing: { genre: string | null; rating: number | null; poster_url: string | null; imdb_id: string | null; tmdb_id?: number | null },
+  existing: {
+    genre: string | null;
+    rating: number | null;
+    poster_url: string | null;
+    imdb_id: string | null;
+    tmdb_id?: number | null;
+    user_rating?: number | null;
+    pl_title?: string | null;
+    filmweb_id?: number | null;
+    filmweb_url?: string | null;
+    rated_at?: string | null;
+    wishlist?: number | null;
+    description?: string | null;
+    cda_url?: string | null;
+    video_metadata?: string | null;
+  },
   incoming: MovieInput,
 ): void {
   const sets: string[] = [];
@@ -257,6 +281,15 @@ function enrichMissingMetadata(
   if (!existing.poster_url && incoming.poster_url) { sets.push("poster_url = ?"); values.push(incoming.poster_url); }
   if (!existing.imdb_id && incoming.imdb_id) { sets.push("imdb_id = ?"); values.push(incoming.imdb_id); }
   if ("tmdb_id" in existing && !existing.tmdb_id && incoming.tmdb_id) { sets.push("tmdb_id = ?"); values.push(incoming.tmdb_id); }
+  if ("user_rating" in existing && existing.user_rating == null && incoming.user_rating != null) { sets.push("user_rating = ?"); values.push(incoming.user_rating); }
+  if ("pl_title" in existing && !existing.pl_title && incoming.pl_title) { sets.push("pl_title = ?"); values.push(incoming.pl_title); }
+  if ("filmweb_id" in existing && existing.filmweb_id == null && incoming.filmweb_id != null) { sets.push("filmweb_id = ?"); values.push(incoming.filmweb_id); }
+  if ("filmweb_url" in existing && !existing.filmweb_url && incoming.filmweb_url) { sets.push("filmweb_url = ?"); values.push(incoming.filmweb_url); }
+  if ("rated_at" in existing && !existing.rated_at && incoming.rated_at) { sets.push("rated_at = ?"); values.push(incoming.rated_at); }
+  if ("description" in existing && !existing.description && incoming.description) { sets.push("description = ?"); values.push(incoming.description); }
+  if ("cda_url" in existing && !existing.cda_url && incoming.cda_url) { sets.push("cda_url = ?"); values.push(incoming.cda_url); }
+  if ("video_metadata" in existing && !existing.video_metadata && incoming.video_metadata) { sets.push("video_metadata = ?"); values.push(incoming.video_metadata); }
+  if ("wishlist" in existing && (existing.wishlist == null || existing.wishlist === 0) && incoming.wishlist === 1) { sets.push("wishlist = ?"); values.push(incoming.wishlist); }
   if (sets.length === 0) return;
   values.push(id);
   db.prepare(`UPDATE movies SET ${sets.join(", ")} WHERE id = ?`).run(...values);
@@ -273,19 +306,19 @@ export function insertMovie(db: Database.Database, movie: MovieInput): number {
   // If a movie with the same tmdb_id already exists, link the file to it
   if (movie.tmdb_id) {
     const byTmdbId = db
-      .prepare("SELECT id, file_path, extra_files, genre, rating, poster_url, imdb_id FROM movies WHERE tmdb_id = ?")
-      .get(movie.tmdb_id) as { id: number; file_path: string | null; extra_files: string | null; genre: string | null; rating: number | null; poster_url: string | null; imdb_id: string | null } | undefined;
+      .prepare("SELECT id, file_path, extra_files, genre, rating, poster_url, imdb_id, user_rating, pl_title, filmweb_id, filmweb_url, rated_at, wishlist, description, cda_url, video_metadata FROM movies WHERE tmdb_id = ?")
+      .get(movie.tmdb_id) as { id: number; file_path: string | null; extra_files: string | null; genre: string | null; rating: number | null; poster_url: string | null; imdb_id: string | null; user_rating: number | null; pl_title: string | null; filmweb_id: number | null; filmweb_url: string | null; rated_at: string | null; wishlist: number | null; description: string | null; cda_url: string | null; video_metadata: string | null } | undefined;
     if (byTmdbId) {
       if (movie.file_path) {
         if (!byTmdbId.file_path) {
           // No primary file yet — set it and bump created_at so it sorts to top of "Date Added"
-          db.prepare("UPDATE movies SET file_path = ?, created_at = CURRENT_TIMESTAMP WHERE id = ?").run(movie.file_path, byTmdbId.id);
+          db.prepare("UPDATE movies SET file_path = ?, video_metadata = NULL, created_at = CURRENT_TIMESTAMP WHERE id = ?").run(movie.file_path, byTmdbId.id);
         } else if (byTmdbId.file_path !== movie.file_path) {
           // Already has a different primary file — add to extra_files to avoid overwrite loop
           const extras: string[] = byTmdbId.extra_files ? JSON.parse(byTmdbId.extra_files) : [];
           if (!extras.includes(movie.file_path)) {
             extras.push(movie.file_path);
-            db.prepare("UPDATE movies SET extra_files = ? WHERE id = ?").run(JSON.stringify(extras), byTmdbId.id);
+            db.prepare("UPDATE movies SET extra_files = ?, video_metadata = NULL WHERE id = ?").run(JSON.stringify(extras), byTmdbId.id);
           }
         }
       }
@@ -300,18 +333,18 @@ export function insertMovie(db: Database.Database, movie: MovieInput): number {
   if (movie.title) {
     const byTitleYear = db
       .prepare(
-        "SELECT id, file_path, extra_files, genre, rating, poster_url, imdb_id, tmdb_id FROM movies WHERE LOWER(title) = LOWER(?) AND year IS ?",
+        "SELECT id, file_path, extra_files, genre, rating, poster_url, imdb_id, tmdb_id, user_rating, pl_title, filmweb_id, filmweb_url, rated_at, wishlist, description, cda_url, video_metadata FROM movies WHERE LOWER(title) = LOWER(?) AND year IS ?",
       )
-      .get(movie.title, movie.year ?? null) as { id: number; file_path: string | null; extra_files: string | null; genre: string | null; rating: number | null; poster_url: string | null; imdb_id: string | null; tmdb_id: number | null } | undefined;
+      .get(movie.title, movie.year ?? null) as { id: number; file_path: string | null; extra_files: string | null; genre: string | null; rating: number | null; poster_url: string | null; imdb_id: string | null; tmdb_id: number | null; user_rating: number | null; pl_title: string | null; filmweb_id: number | null; filmweb_url: string | null; rated_at: string | null; wishlist: number | null; description: string | null; cda_url: string | null; video_metadata: string | null } | undefined;
     if (byTitleYear) {
       if (movie.file_path) {
         if (!byTitleYear.file_path) {
-          db.prepare("UPDATE movies SET file_path = ?, created_at = CURRENT_TIMESTAMP WHERE id = ?").run(movie.file_path, byTitleYear.id);
+          db.prepare("UPDATE movies SET file_path = ?, video_metadata = NULL, created_at = CURRENT_TIMESTAMP WHERE id = ?").run(movie.file_path, byTitleYear.id);
         } else if (byTitleYear.file_path !== movie.file_path) {
           const extras: string[] = byTitleYear.extra_files ? JSON.parse(byTitleYear.extra_files) : [];
           if (!extras.includes(movie.file_path)) {
             extras.push(movie.file_path);
-            db.prepare("UPDATE movies SET extra_files = ? WHERE id = ?").run(JSON.stringify(extras), byTitleYear.id);
+            db.prepare("UPDATE movies SET extra_files = ?, video_metadata = NULL WHERE id = ?").run(JSON.stringify(extras), byTitleYear.id);
           }
         }
       }
@@ -322,8 +355,8 @@ export function insertMovie(db: Database.Database, movie: MovieInput): number {
   }
 
   const stmt = db.prepare(`
-    INSERT INTO movies (title, year, genre, director, writer, actors, rating, poster_url, source, imdb_id, tmdb_id, type, file_path, extra_files)
-    VALUES (@title, @year, @genre, @director, @writer, @actors, @rating, @poster_url, @source, @imdb_id, @tmdb_id, @type, @file_path, @extra_files)
+    INSERT INTO movies (title, year, genre, director, writer, actors, rating, poster_url, source, imdb_id, tmdb_id, type, file_path, extra_files, user_rating, pl_title, filmweb_id, filmweb_url, rated_at, wishlist, description, cda_url, video_metadata)
+    VALUES (@title, @year, @genre, @director, @writer, @actors, @rating, @poster_url, @source, @imdb_id, @tmdb_id, @type, @file_path, @extra_files, @user_rating, @pl_title, @filmweb_id, @filmweb_url, @rated_at, @wishlist, @description, @cda_url, @video_metadata)
   `);
   const result = stmt.run({
     ...movie,
@@ -331,6 +364,15 @@ export function insertMovie(db: Database.Database, movie: MovieInput): number {
     actors: movie.actors ?? null,
     file_path: movie.file_path ?? null,
     extra_files: movie.extra_files ?? null,
+    user_rating: movie.user_rating ?? null,
+    pl_title: movie.pl_title ?? null,
+    filmweb_id: movie.filmweb_id ?? null,
+    filmweb_url: movie.filmweb_url ?? null,
+    rated_at: movie.rated_at ?? null,
+    wishlist: movie.wishlist ?? 0,
+    description: movie.description ?? null,
+    cda_url: movie.cda_url ?? null,
+    video_metadata: movie.video_metadata ?? null,
   });
   return Number(result.lastInsertRowid);
 }


### PR DESCRIPTION
Closes #82

Picked ready bug `#82`, created the TamTam issue branch, implemented detach-instead-of-delete sync cleanup, updated the sync modal wording, and added a preservation regression test.

---
Implemented via TamTam from issue [#82](https://github.com/3h4x/film-pick/issues/82).