### PR TITLE
fix: Use canonical TMDb rows consistently across duplicate search and recommendation flows

### DIFF
--- a/__tests__/import-api.test.ts
+++ b/__tests__/import-api.test.ts
@@ -105,6 +105,7 @@ describe("import API route", () => {
 
     expect(complete).toBeDefined();
     expect(complete!.added).toBe(0);
+    expect(complete!.linked).toBe(0);
     expect(complete!.skipped).toBe(0);
     expect(complete!.failed).toBe(0);
     expect(complete!.total).toBe(0);
@@ -172,6 +173,7 @@ describe("import API route", () => {
     const complete = lines.find((l) => l.type === "complete");
 
     expect(complete!.added).toBe(1);
+    expect(complete!.linked).toBe(0);
     expect(complete!.skipped).toBe(0);
     expect(complete!.failed).toBe(0);
   });
@@ -195,6 +197,7 @@ describe("import API route", () => {
     const complete = lines.find((l) => l.type === "complete");
 
     expect(complete!.added).toBe(1);
+    expect(complete!.linked).toBe(0);
     expect(complete!.failed).toBe(0);
   });
 
@@ -232,6 +235,7 @@ describe("import API route", () => {
 
     expect(complete!.skipped).toBe(1);
     expect(complete!.added).toBe(0);
+    expect(complete!.linked).toBe(0);
   });
 
   it("counts failed=1 when TMDb throws an error", async () => {
@@ -254,6 +258,7 @@ describe("import API route", () => {
 
     expect(complete!.failed).toBe(1);
     expect(complete!.added).toBe(0);
+    expect(complete!.linked).toBe(0);
   });
 
   // ── Year-proximity matching ─────────────────────────────────────────────────
@@ -288,6 +293,7 @@ describe("import API route", () => {
     const complete = lines.find((l) => l.type === "complete");
 
     expect(complete!.added).toBe(1);
+    expect(complete!.linked).toBe(0);
     expect(complete!.failed).toBe(0);
 
     const row = db
@@ -327,6 +333,7 @@ describe("import API route", () => {
     const complete = lines.find((l) => l.type === "complete");
 
     expect(complete!.added).toBe(1);
+    expect(complete!.linked).toBe(0);
 
     const row = db
       .prepare("SELECT tmdb_id FROM movies WHERE tmdb_id = 395992")
@@ -363,6 +370,7 @@ describe("import API route", () => {
     const complete = lines.find((l) => l.type === "complete");
 
     expect(complete!.added).toBe(1);
+    expect(complete!.linked).toBe(0);
 
     const row = db
       .prepare("SELECT tmdb_id FROM movies WHERE tmdb_id = 289")
@@ -400,26 +408,407 @@ describe("import API route", () => {
       type: "movie",
       file_path: "/movies/already.mkv",
     });
+    insertMovie(db, {
+      title: "Linked Film",
+      year: 2021,
+      genre: null,
+      director: null,
+      rating: null,
+      poster_url: null,
+      source: "filmweb",
+      imdb_id: null,
+      tmdb_id: null,
+      type: "movie",
+      wishlist: 1,
+    });
 
     vi.mocked(scanDirectoryGenerator).mockReturnValue(
       (function* () {
         yield { filePath: "/movies/already.mkv", filename: "already.mkv", parsedTitle: "Already Here", parsedYear: 2000 };
         yield { filePath: "/movies/new.mkv", filename: "new.mkv", parsedTitle: "New Film", parsedYear: 2023 };
+        yield { filePath: "/movies/linked.mkv", filename: "linked.mkv", parsedTitle: "Linked Film", parsedYear: 2021 };
         yield { filePath: "/movies/broken.mkv", filename: "broken.mkv", parsedTitle: "Broken", parsedYear: 2022 };
       })() as ReturnType<typeof scanDirectoryGenerator>,
     );
 
     vi.mocked(searchTmdb)
       .mockResolvedValueOnce([{ title: "New Film", year: 2023, genre: "Action", rating: 7.0, poster_url: null, tmdb_id: 999, imdb_id: null }])
+      .mockResolvedValueOnce([])
       .mockRejectedValueOnce(new Error("timeout"));
 
     const res = await POST(makeRequest({ path: "/movies" }));
     const lines = await readNDJSON(res);
     const complete = lines.find((l) => l.type === "complete");
 
-    expect(complete!.total).toBe(3);
+    expect(complete!.total).toBe(4);
     expect(complete!.skipped).toBe(1);
     expect(complete!.added).toBe(1);
+    expect(complete!.linked).toBe(1);
     expect(complete!.failed).toBe(1);
+  });
+
+  it("links a scanned file to an existing pathless row by tmdb_id", async () => {
+    const { insertMovie } = await import("@/lib/db");
+    insertMovie(db, {
+      title: "Adwokat",
+      year: 2013,
+      genre: null,
+      director: null,
+      rating: null,
+      poster_url: null,
+      source: "tmdb",
+      imdb_id: null,
+      tmdb_id: 109091,
+      type: "movie",
+      wishlist: 1,
+    });
+
+    vi.mocked(scanDirectoryGenerator).mockReturnValue(
+      (function* () {
+        yield {
+          filePath: "/movies/The.Counselor.2013.mkv",
+          filename: "The.Counselor.2013.mkv",
+          parsedTitle: "The Counselor",
+          parsedYear: 2013,
+        };
+      })() as ReturnType<typeof scanDirectoryGenerator>,
+    );
+    vi.mocked(searchTmdb).mockResolvedValue([
+      {
+        title: "The Counselor",
+        year: 2013,
+        genre: "Drama",
+        rating: 5.3,
+        poster_url: null,
+        tmdb_id: 109091,
+        imdb_id: "tt2193215",
+      },
+    ]);
+
+    const res = await POST(makeRequest({ path: "/movies" }));
+    const lines = await readNDJSON(res);
+    const complete = lines.find((line) => line.type === "complete");
+
+    expect(complete!.added).toBe(0);
+    expect(complete!.linked).toBe(1);
+    expect(complete!.skipped).toBe(0);
+
+    const rows = db.prepare(
+      "SELECT title, file_path, wishlist, genre, rating, imdb_id FROM movies",
+    ).all() as Array<{
+      title: string;
+      file_path: string | null;
+      wishlist: number;
+      genre: string | null;
+      rating: number | null;
+      imdb_id: string | null;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      title: "Adwokat",
+      file_path: "/movies/The.Counselor.2013.mkv",
+      wishlist: 1,
+      genre: "Drama",
+      rating: 5.3,
+      imdb_id: "tt2193215",
+    });
+  });
+
+  it("enriches a linked pathless row with TMDb metadata while preserving user-owned fields", async () => {
+    db.prepare(
+      "INSERT INTO movies (title, year, source, type, user_rating, wishlist, filmweb_id, filmweb_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "The Counselor",
+      null,
+      "filmweb",
+      "movie",
+      9,
+      1,
+      12345,
+      "https://filmweb.example/the-counselor",
+    );
+
+    vi.mocked(scanDirectoryGenerator).mockReturnValue(
+      (function* () {
+        yield {
+          filePath: "/movies/The.Counselor.2013.mkv",
+          filename: "The.Counselor.2013.mkv",
+          parsedTitle: "The Counselor",
+          parsedYear: 2013,
+        };
+      })() as ReturnType<typeof scanDirectoryGenerator>,
+    );
+    vi.mocked(searchTmdb).mockResolvedValue([
+      {
+        title: "The Counselor",
+        year: 2013,
+        genre: "Drama",
+        rating: 5.3,
+        poster_url: "/poster.jpg",
+        tmdb_id: 109091,
+        imdb_id: "tt2193215",
+      },
+    ]);
+
+    const res = await POST(makeRequest({ path: "/movies" }));
+    const lines = await readNDJSON(res);
+    const complete = lines.find((line) => line.type === "complete");
+
+    expect(complete!.added).toBe(0);
+    expect(complete!.linked).toBe(1);
+
+    const row = db.prepare(
+      "SELECT year, file_path, tmdb_id, imdb_id, genre, rating, poster_url, user_rating, wishlist, filmweb_id, filmweb_url FROM movies WHERE title = ?",
+    ).get("The Counselor") as {
+      year: number | null;
+      file_path: string | null;
+      tmdb_id: number | null;
+      imdb_id: string | null;
+      genre: string | null;
+      rating: number | null;
+      poster_url: string | null;
+      user_rating: number | null;
+      wishlist: number;
+      filmweb_id: number | null;
+      filmweb_url: string | null;
+    };
+    expect(row).toMatchObject({
+      year: 2013,
+      file_path: "/movies/The.Counselor.2013.mkv",
+      tmdb_id: 109091,
+      imdb_id: "tt2193215",
+      genre: "Drama",
+      rating: 5.3,
+      poster_url: "/poster.jpg",
+      user_rating: 9,
+      wishlist: 1,
+      filmweb_id: 12345,
+      filmweb_url: "https://filmweb.example/the-counselor",
+    });
+  });
+
+  it("links a scanned file to an existing normalized-title pathless row within ±1 year", async () => {
+    const { insertMovie } = await import("@/lib/db");
+    insertMovie(db, {
+      title: "Spider-Man: Homecoming",
+      year: 2017,
+      genre: null,
+      director: null,
+      rating: null,
+      poster_url: null,
+      source: "filmweb",
+      imdb_id: null,
+      tmdb_id: null,
+      type: "movie",
+      wishlist: 1,
+    });
+
+    vi.mocked(scanDirectoryGenerator).mockReturnValue(
+      (function* () {
+        yield {
+          filePath: "/movies/Spider.Man.Homecoming.2018.1080p.mkv",
+          filename: "Spider.Man.Homecoming.2018.1080p.mkv",
+          parsedTitle: "Spider Man Homecoming",
+          parsedYear: 2018,
+        };
+      })() as ReturnType<typeof scanDirectoryGenerator>,
+    );
+    vi.mocked(searchTmdb).mockResolvedValue([]);
+
+    const res = await POST(makeRequest({ path: "/movies" }));
+    const lines = await readNDJSON(res);
+    const complete = lines.find((line) => line.type === "complete");
+
+    expect(complete!.added).toBe(0);
+    expect(complete!.linked).toBe(1);
+
+    const rows = db.prepare(
+      "SELECT title, file_path, wishlist FROM movies",
+    ).all() as Array<{
+      title: string;
+      file_path: string | null;
+      wishlist: number;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      title: "Spider-Man: Homecoming",
+      file_path: "/movies/Spider.Man.Homecoming.2018.1080p.mkv",
+      wishlist: 1,
+    });
+  });
+
+  it("preserves existing Filmweb and wishlist fields when import links to a pathless row", async () => {
+    db.prepare(
+      "INSERT INTO movies (title, year, source, type, user_rating, wishlist, filmweb_id, filmweb_url, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "Inception",
+      2010,
+      "filmweb",
+      "movie",
+      9,
+      1,
+      12345,
+      "https://filmweb.example/inception",
+      "2001-01-01 00:00:00",
+    );
+
+    vi.mocked(scanDirectoryGenerator).mockReturnValue(
+      (function* () {
+        yield {
+          filePath: "/movies/Inception.2010.mkv",
+          filename: "Inception.2010.mkv",
+          parsedTitle: "Inception",
+          parsedYear: 2010,
+        };
+      })() as ReturnType<typeof scanDirectoryGenerator>,
+    );
+
+    const res = await POST(makeRequest({ path: "/movies" }));
+    const lines = await readNDJSON(res);
+    const complete = lines.find((line) => line.type === "complete");
+
+    expect(complete!.added).toBe(0);
+    expect(complete!.linked).toBe(1);
+
+    const row = db.prepare(
+      "SELECT file_path, user_rating, wishlist, filmweb_id, filmweb_url, created_at FROM movies WHERE title = ?",
+    ).get("Inception") as {
+      file_path: string | null;
+      user_rating: number | null;
+      wishlist: number;
+      filmweb_id: number | null;
+      filmweb_url: string | null;
+      created_at: string;
+    };
+    expect(row.file_path).toBe("/movies/Inception.2010.mkv");
+    expect(row.user_rating).toBe(9);
+    expect(row.wishlist).toBe(1);
+    expect(row.filmweb_id).toBe(12345);
+    expect(row.filmweb_url).toBe("https://filmweb.example/inception");
+    expect(row.created_at).not.toBe("2001-01-01 00:00:00");
+  });
+
+  it("does not enrich a linked pathless row from a far-off TMDb fallback result", async () => {
+    db.prepare(
+      "INSERT INTO movies (title, year, source, type, wishlist) VALUES (?, ?, ?, ?, ?)",
+    ).run("Alien", 1979, "filmweb", "movie", 1);
+
+    vi.mocked(scanDirectoryGenerator).mockReturnValue(
+      (function* () {
+        yield {
+          filePath: "/movies/Alien.1979.mkv",
+          filename: "Alien.1979.mkv",
+          parsedTitle: "Alien",
+          parsedYear: 1979,
+        };
+      })() as ReturnType<typeof scanDirectoryGenerator>,
+    );
+    vi.mocked(searchTmdb).mockResolvedValue([
+      {
+        title: "Alien: Covenant",
+        year: 2017,
+        genre: "Horror, Sci-Fi",
+        rating: 6.1,
+        poster_url: "/alien-covenant.jpg",
+        tmdb_id: 126889,
+        imdb_id: "tt2316204",
+      },
+    ]);
+
+    const res = await POST(makeRequest({ path: "/movies" }));
+    const lines = await readNDJSON(res);
+    const complete = lines.find((line) => line.type === "complete");
+
+    expect(complete!.added).toBe(0);
+    expect(complete!.linked).toBe(1);
+
+    const row = db.prepare(
+      "SELECT file_path, tmdb_id, imdb_id, genre, rating, poster_url, wishlist FROM movies WHERE title = ?",
+    ).get("Alien") as {
+      file_path: string | null;
+      tmdb_id: number | null;
+      imdb_id: string | null;
+      genre: string | null;
+      rating: number | null;
+      poster_url: string | null;
+      wishlist: number;
+    };
+    expect(row).toMatchObject({
+      file_path: "/movies/Alien.1979.mkv",
+      tmdb_id: null,
+      imdb_id: null,
+      genre: null,
+      rating: null,
+      poster_url: null,
+      wishlist: 1,
+    });
+  });
+
+  it("counts fallback TMDb merges into existing pathless rows as linked, not added", async () => {
+    const { insertMovie } = await import("@/lib/db");
+    insertMovie(db, {
+      title: "Adwokat",
+      year: 2013,
+      genre: null,
+      director: null,
+      rating: null,
+      poster_url: null,
+      source: "filmweb",
+      imdb_id: null,
+      tmdb_id: 109091,
+      type: "movie",
+      wishlist: 1,
+    });
+
+    vi.mocked(scanDirectoryGenerator).mockReturnValue(
+      (function* () {
+        yield {
+          filePath: "/movies/Bad.Filename.2013.mkv",
+          filename: "Bad.Filename.2013.mkv",
+          parsedTitle: "Bad Filename",
+          parsedYear: 2013,
+        };
+      })() as ReturnType<typeof scanDirectoryGenerator>,
+    );
+    vi.mocked(searchTmdb).mockResolvedValue([
+      {
+        title: "The Counselor",
+        year: 2013,
+        genre: "Drama",
+        rating: 5.3,
+        poster_url: "/poster.jpg",
+        tmdb_id: 109091,
+        imdb_id: "tt2193215",
+      },
+    ]);
+
+    const res = await POST(makeRequest({ path: "/movies" }));
+    const lines = await readNDJSON(res);
+    const complete = lines.find((line) => line.type === "complete");
+
+    expect(complete!.added).toBe(0);
+    expect(complete!.linked).toBe(1);
+
+    const rows = db.prepare(
+      "SELECT title, file_path, tmdb_id, genre, rating, poster_url, wishlist FROM movies",
+    ).all() as Array<{
+      title: string;
+      file_path: string | null;
+      tmdb_id: number | null;
+      genre: string | null;
+      rating: number | null;
+      poster_url: string | null;
+      wishlist: number;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      title: "Adwokat",
+      file_path: "/movies/Bad.Filename.2013.mkv",
+      tmdb_id: 109091,
+      genre: "Drama",
+      rating: 5.3,
+      poster_url: "/poster.jpg",
+      wishlist: 1,
+    });
   });
 });

--- a/__tests__/search-api.test.ts
+++ b/__tests__/search-api.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@/lib/tmdb", () => ({
-  searchTmdb: vi.fn(),
+  searchTmdbForUi: vi.fn(),
 }));
 
 import { GET } from "@/app/api/search/route";
-import { searchTmdb } from "@/lib/tmdb";
+import { searchTmdbForUi } from "@/lib/tmdb";
 
-const mockSearchTmdb = vi.mocked(searchTmdb);
+const mockSearchTmdbForUi = vi.mocked(searchTmdbForUi);
 
 function makeRequest(query?: string) {
   const url = query !== undefined
@@ -39,7 +39,7 @@ describe("GET /api/search", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual([]);
-    expect(mockSearchTmdb).not.toHaveBeenCalled();
+    expect(mockSearchTmdbForUi).not.toHaveBeenCalled();
   });
 
   it("returns empty array when query is empty string", async () => {
@@ -47,7 +47,7 @@ describe("GET /api/search", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual([]);
-    expect(mockSearchTmdb).not.toHaveBeenCalled();
+    expect(mockSearchTmdbForUi).not.toHaveBeenCalled();
   });
 
   it("returns empty array when query is whitespace only", async () => {
@@ -55,11 +55,11 @@ describe("GET /api/search", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual([]);
-    expect(mockSearchTmdb).not.toHaveBeenCalled();
+    expect(mockSearchTmdbForUi).not.toHaveBeenCalled();
   });
 
   it("returns search results for a valid query", async () => {
-    mockSearchTmdb.mockResolvedValueOnce(sampleResults);
+    mockSearchTmdbForUi.mockResolvedValueOnce(sampleResults);
 
     const res = await GET(makeRequest("inception"));
     expect(res.status).toBe(200);
@@ -67,18 +67,18 @@ describe("GET /api/search", () => {
     expect(body).toHaveLength(1);
     expect(body[0].title).toBe("Inception");
     expect(body[0].tmdb_id).toBe(27205);
-    expect(mockSearchTmdb).toHaveBeenCalledWith("inception");
+    expect(mockSearchTmdbForUi).toHaveBeenCalledWith("inception");
   });
 
-  it("passes the exact query string to searchTmdb", async () => {
-    mockSearchTmdb.mockResolvedValueOnce([]);
+  it("passes the exact query string to searchTmdbForUi", async () => {
+    mockSearchTmdbForUi.mockResolvedValueOnce([]);
 
     await GET(makeRequest("The Dark Knight"));
-    expect(mockSearchTmdb).toHaveBeenCalledWith("The Dark Knight");
+    expect(mockSearchTmdbForUi).toHaveBeenCalledWith("The Dark Knight");
   });
 
   it("returns empty array when TMDb finds no results", async () => {
-    mockSearchTmdb.mockResolvedValueOnce([]);
+    mockSearchTmdbForUi.mockResolvedValueOnce([]);
 
     const res = await GET(makeRequest("xyzzy-nonexistent-film-12345"));
     expect(res.status).toBe(200);
@@ -87,7 +87,7 @@ describe("GET /api/search", () => {
   });
 
   it("returns 503 with no_api_key when TMDB_API_KEY is not set", async () => {
-    mockSearchTmdb.mockRejectedValueOnce(new Error("TMDB_API_KEY not set"));
+    mockSearchTmdbForUi.mockRejectedValueOnce(new Error("TMDB_API_KEY not set"));
 
     const res = await GET(makeRequest("inception"));
     expect(res.status).toBe(503);
@@ -96,7 +96,7 @@ describe("GET /api/search", () => {
   });
 
   it("returns 503 with no_api_key for tmdb_api_error", async () => {
-    mockSearchTmdb.mockRejectedValueOnce(new Error("tmdb_api_error: 401 Unauthorized"));
+    mockSearchTmdbForUi.mockRejectedValueOnce(new Error("tmdb_api_error: 401 Unauthorized"));
 
     const res = await GET(makeRequest("inception"));
     expect(res.status).toBe(503);
@@ -105,7 +105,7 @@ describe("GET /api/search", () => {
   });
 
   it("returns 500 for unexpected errors", async () => {
-    mockSearchTmdb.mockRejectedValueOnce(new Error("Network timeout"));
+    mockSearchTmdbForUi.mockRejectedValueOnce(new Error("Network timeout"));
 
     const res = await GET(makeRequest("inception"));
     expect(res.status).toBe(500);
@@ -114,7 +114,7 @@ describe("GET /api/search", () => {
   });
 
   it("returns 500 with generic message when error has no message", async () => {
-    mockSearchTmdb.mockRejectedValueOnce({});
+    mockSearchTmdbForUi.mockRejectedValueOnce({});
 
     const res = await GET(makeRequest("inception"));
     expect(res.status).toBe(500);
@@ -127,7 +127,7 @@ describe("GET /api/search", () => {
       { ...sampleResults[0] },
       { title: "Inception 2", year: 2025, genre: "Sci-Fi", rating: 7.5, poster_url: null, tmdb_id: 99999, imdb_id: null },
     ];
-    mockSearchTmdb.mockResolvedValueOnce(multiResults);
+    mockSearchTmdbForUi.mockResolvedValueOnce(multiResults);
 
     const res = await GET(makeRequest("inception"));
     expect(res.status).toBe(200);

--- a/__tests__/sync-api.test.ts
+++ b/__tests__/sync-api.test.ts
@@ -153,7 +153,6 @@ describe("sync API route", () => {
     const complete = events.find((e) => e.type === "complete");
     expect(complete!.linked).toBe(1);
     expect(complete!.added).toBe(0);
-    expect(searchTmdb).not.toHaveBeenCalled();
 
     const movies = db.prepare("SELECT * FROM movies").all() as { file_path: string }[];
     expect(movies).toHaveLength(1);
@@ -437,7 +436,6 @@ describe("sync API route", () => {
     const complete = events.find((e) => e.type === "complete");
     expect(complete!.linked).toBe(1);
     expect(complete!.added).toBe(0);
-    expect(searchTmdb).not.toHaveBeenCalled();
 
     const movies = db.prepare("SELECT * FROM movies").all() as { file_path: string; source: string }[];
     expect(movies).toHaveLength(1);
@@ -482,10 +480,97 @@ describe("sync API route", () => {
     expect(complete!.linked).toBe(1);
     expect(complete!.added).toBe(0);
 
-    const movies = db.prepare("SELECT * FROM movies").all() as { title: string; file_path: string }[];
+    const movies = db.prepare(
+      "SELECT title, file_path, genre, rating, imdb_id FROM movies",
+    ).all() as Array<{
+      title: string;
+      file_path: string;
+      genre: string | null;
+      rating: number | null;
+      imdb_id: string | null;
+    }>;
     expect(movies).toHaveLength(1);
-    expect(movies[0].title).toBe("Adwokat");
-    expect(movies[0].file_path).toBe("/movies/The.Counselor.2013.mkv");
+    expect(movies[0]).toMatchObject({
+      title: "Adwokat",
+      file_path: "/movies/The.Counselor.2013.mkv",
+      genre: "Drama",
+      rating: 5.3,
+      imdb_id: "tt2193215",
+    });
+  });
+
+  it("enriches a linked pathless row with TMDb metadata while preserving user-owned fields", async () => {
+    setSetting(db as unknown as ReturnType<typeof getDb>, "library_path", "/movies");
+    db.prepare(
+      "INSERT INTO movies (title, year, source, type, user_rating, wishlist, filmweb_id, filmweb_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "The Counselor",
+      null,
+      "filmweb",
+      "movie",
+      9,
+      1,
+      12345,
+      "https://filmweb.example/the-counselor",
+    );
+
+    vi.mocked(scanDirectoryGenerator).mockReturnValue(
+      (function* () {
+        yield {
+          filename: "The.Counselor.2013.mkv",
+          filePath: "/movies/The.Counselor.2013.mkv",
+          parsedTitle: "The Counselor",
+          parsedYear: 2013,
+        };
+      })(),
+    );
+    vi.mocked(searchTmdb).mockResolvedValue([
+      {
+        title: "The Counselor",
+        year: 2013,
+        genre: "Drama",
+        rating: 5.3,
+        poster_url: "/poster.jpg",
+        imdb_id: "tt2193215",
+        tmdb_id: 109091,
+      },
+    ]);
+
+    const res = await POST();
+    const events = await readNDJSON(res);
+
+    const complete = events.find((e) => e.type === "complete");
+    expect(complete!.linked).toBe(1);
+    expect(complete!.added).toBe(0);
+
+    const row = db.prepare(
+      "SELECT year, file_path, tmdb_id, imdb_id, genre, rating, poster_url, user_rating, wishlist, filmweb_id, filmweb_url FROM movies WHERE title = ?",
+    ).get("The Counselor") as {
+      year: number | null;
+      file_path: string | null;
+      tmdb_id: number | null;
+      imdb_id: string | null;
+      genre: string | null;
+      rating: number | null;
+      poster_url: string | null;
+      user_rating: number | null;
+      wishlist: number;
+      filmweb_id: number | null;
+      filmweb_url: string | null;
+    };
+    expect(row).toMatchObject({
+      year: 2013,
+      file_path: "/movies/The.Counselor.2013.mkv",
+      tmdb_id: 109091,
+      imdb_id: "tt2193215",
+      genre: "Drama",
+      rating: 5.3,
+      poster_url: "/poster.jpg",
+      user_rating: 9,
+      wishlist: 1,
+      filmweb_id: 12345,
+      filmweb_url: "https://filmweb.example/the-counselor",
+    });
   });
 
   it("links to existing pathless row by title+year when TMDb throws (no duplicate local row)", async () => {
@@ -526,6 +611,131 @@ describe("sync API route", () => {
     expect(movies).toHaveLength(1);
     expect(movies[0].source).toBe("filmweb");
     expect(movies[0].file_path).toBe("/movies/Some.Film.2000.mkv");
+  });
+
+  it("does not enrich a linked pathless row from a far-off TMDb fallback result", async () => {
+    setSetting(db as unknown as ReturnType<typeof getDb>, "library_path", "/movies");
+    db.prepare(
+      "INSERT INTO movies (title, year, source, type, wishlist) VALUES (?, ?, ?, ?, ?)",
+    ).run("Spider-Man: Homecoming", 2017, "filmweb", "movie", 1);
+
+    vi.mocked(scanDirectoryGenerator).mockReturnValue(
+      (function* () {
+        yield {
+          filename: "Spider.Man.Homecoming.2018.1080p.mkv",
+          filePath: "/movies/Spider.Man.Homecoming.2018.1080p.mkv",
+          parsedTitle: "Spider Man Homecoming",
+          parsedYear: 2018,
+        };
+      })(),
+    );
+    vi.mocked(searchTmdb).mockResolvedValue([
+      {
+        title: "Spider-Man: No Way Home",
+        year: 2021,
+        genre: "Action",
+        rating: 8.2,
+        poster_url: "/spider-man-no-way-home.jpg",
+        imdb_id: "tt10872600",
+        tmdb_id: 634649,
+      },
+    ]);
+
+    const res = await POST();
+    const events = await readNDJSON(res);
+
+    const complete = events.find((e) => e.type === "complete");
+    expect(complete!.linked).toBe(1);
+    expect(complete!.added).toBe(0);
+
+    const row = db.prepare(
+      "SELECT file_path, tmdb_id, imdb_id, genre, rating, poster_url, wishlist FROM movies WHERE title = ?",
+    ).get("Spider-Man: Homecoming") as {
+      file_path: string | null;
+      tmdb_id: number | null;
+      imdb_id: string | null;
+      genre: string | null;
+      rating: number | null;
+      poster_url: string | null;
+      wishlist: number;
+    };
+    expect(row).toMatchObject({
+      file_path: "/movies/Spider.Man.Homecoming.2018.1080p.mkv",
+      tmdb_id: null,
+      imdb_id: null,
+      genre: null,
+      rating: null,
+      poster_url: null,
+      wishlist: 1,
+    });
+  });
+
+  it("counts fallback TMDb merges into existing pathless rows as linked, not added", async () => {
+    setSetting(db as unknown as ReturnType<typeof getDb>, "library_path", "/movies");
+    insertMovie(db as unknown as ReturnType<typeof getDb>, {
+      title: "Adwokat",
+      year: 2013,
+      genre: null,
+      director: null,
+      rating: null,
+      poster_url: null,
+      source: "filmweb",
+      imdb_id: null,
+      tmdb_id: 109091,
+      type: "movie",
+      wishlist: 1,
+    });
+
+    vi.mocked(scanDirectoryGenerator).mockReturnValue(
+      (function* () {
+        yield {
+          filename: "Bad.Filename.2013.mkv",
+          filePath: "/movies/Bad.Filename.2013.mkv",
+          parsedTitle: "Bad Filename",
+          parsedYear: 2013,
+        };
+      })(),
+    );
+    vi.mocked(searchTmdb).mockResolvedValue([
+      {
+        title: "The Counselor",
+        year: 2013,
+        genre: "Drama",
+        rating: 5.3,
+        poster_url: "/poster.jpg",
+        imdb_id: "tt2193215",
+        tmdb_id: 109091,
+      },
+    ]);
+
+    const res = await POST();
+    const events = await readNDJSON(res);
+
+    const complete = events.find((e) => e.type === "complete");
+    expect(complete!.linked).toBe(1);
+    expect(complete!.added).toBe(0);
+
+    const rows = db.prepare(
+      "SELECT title, file_path, tmdb_id, genre, rating, poster_url, wishlist FROM movies",
+    ).all() as Array<{
+      title: string;
+      file_path: string | null;
+      tmdb_id: number | null;
+      genre: string | null;
+      rating: number | null;
+      poster_url: string | null;
+      wishlist: number;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      title: "Adwokat",
+      file_path: "/movies/Bad.Filename.2013.mkv",
+      tmdb_id: 109091,
+      genre: "Drama",
+      rating: 5.3,
+      poster_url: "/poster.jpg",
+      wishlist: 1,
+    });
   });
 
   it("emits scanning progress events during phase 1", async () => {

--- a/__tests__/tmdb.test.ts
+++ b/__tests__/tmdb.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/db", () => ({
 
 import {
   searchTmdb,
+  searchTmdbForUi,
   getTmdbRecommendations,
   getTmdbSimilar,
   genreNameToId,
@@ -129,6 +130,128 @@ describe("tmdb client", () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 401, statusText: "Unauthorized", text: async () => "" });
 
     await expect(searchTmdb("inception")).rejects.toThrow("tmdb_api_error:401");
+  });
+
+  it("falls back to person filmography when direct movie search is empty", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ results: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            { id: 1, name: "Mia Goth", popularity: 15, known_for_department: "Acting" },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          cast: [
+            {
+              id: 950387,
+              title: "Pearl",
+              release_date: "2022-09-16",
+              genre_ids: [27],
+              vote_average: 7.2,
+              poster_path: "/pearl.jpg",
+              popularity: 30,
+            },
+            {
+              id: 760104,
+              title: "X",
+              release_date: "2022-03-18",
+              genre_ids: [27],
+              vote_average: 6.8,
+              poster_path: "/x.jpg",
+              popularity: 25,
+            },
+          ],
+          crew: [],
+        }),
+      });
+
+    const results = await searchTmdbForUi("mia goth");
+    expect(results).toHaveLength(2);
+    expect(results[0].title).toBe("Pearl");
+    expect(results[1].title).toBe("X");
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("/search/person?query=mia%20goth"),
+      expect.any(Object),
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining("/person/1/movie_credits"),
+      expect.any(Object),
+    );
+  });
+
+  it("deduplicates person fallback filmography results by tmdb_id", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ results: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            { id: 10, name: "Director One", popularity: 12, known_for_department: "Directing" },
+            { id: 11, name: "Actor Two", popularity: 11, known_for_department: "Acting" },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          cast: [],
+          crew: [
+            {
+              id: 101,
+              title: "Shared Movie",
+              release_date: "2021-01-01",
+              genre_ids: [18],
+              vote_average: 7.3,
+              poster_path: "/shared-a.jpg",
+              popularity: 18,
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          cast: [
+            {
+              id: 101,
+              title: "Shared Movie",
+              release_date: "2021-01-01",
+              genre_ids: [18],
+              vote_average: 7.3,
+              poster_path: "/shared-b.jpg",
+              popularity: 22,
+            },
+            {
+              id: 102,
+              title: "Unique Movie",
+              release_date: "2020-01-01",
+              genre_ids: [35],
+              vote_average: 6.5,
+              poster_path: "/unique.jpg",
+              popularity: 10,
+            },
+          ],
+          crew: [],
+        }),
+      });
+
+    const results = await searchTmdbForUi("shared person");
+    expect(results).toHaveLength(2);
+    expect(results.map((result) => result.tmdb_id)).toEqual([101, 102]);
+    expect(results[0].poster_url).toContain("/shared-b.jpg");
   });
 
   it("fetches recommendations for a tmdb id", async () => {

--- a/app/api/import/route.ts
+++ b/app/api/import/route.ts
@@ -1,7 +1,18 @@
 import { NextRequest } from "next/server";
-import { getDb, insertMovie, getMovieByFilePath, setSetting } from "@/lib/db";
+import {
+  enrichMovieMetadata,
+  getDb,
+  getExistingMovieInsertTargetId,
+  getMovieByFilePath,
+  insertMovie,
+  type MovieInput,
+  movieNeedsTmdbEnrichment,
+  setSetting,
+} from "@/lib/db";
+import { linkToExistingPathlessRow } from "@/lib/pathless-row-link";
 import { scanDirectoryGenerator } from "@/lib/scanner";
 import { searchTmdb } from "@/lib/tmdb";
+import { selectTmdbSearchCandidates } from "@/lib/tmdb-match";
 import fs from "fs";
 
 export async function POST(request: NextRequest) {
@@ -25,7 +36,17 @@ export async function POST(request: NextRequest) {
   // Save the library path for future syncs
   setSetting(db, "library_path", dirPath);
 
-  const results = { added: 0, skipped: 0, failed: 0, total: 0 };
+  const results = { added: 0, linked: 0, skipped: 0, failed: 0, total: 0 };
+
+  function insertAndCount(movie: MovieInput) {
+    const existingTargetId = getExistingMovieInsertTargetId(db, movie);
+    insertMovie(db, movie);
+    if (existingTargetId != null) {
+      results.linked++;
+    } else {
+      results.added++;
+    }
+  }
 
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
@@ -57,38 +78,68 @@ export async function POST(request: NextRequest) {
         if (getMovieByFilePath(db, file.filePath)) {
           results.skipped++;
         } else {
+          const linkedRowId = linkToExistingPathlessRow(db, file, null);
+          const shouldEnrichLinkedRow =
+            linkedRowId != null && movieNeedsTmdbEnrichment(db, linkedRowId);
+
+          if (linkedRowId != null && !shouldEnrichLinkedRow) {
+            results.linked++;
+            continue;
+          }
+
           // Search TMDb for metadata
           try {
             const searchResults = await searchTmdb(
               file.parsedTitle,
               file.parsedYear,
             );
-            const match =
-              searchResults.find((r) => {
-                if (file.parsedYear && r.year) {
-                  return Math.abs(r.year - file.parsedYear) <= 1;
-                }
-                return true;
-              }) || searchResults[0];
+            const { strongMatch, fallbackMatch } = selectTmdbSearchCandidates(
+              searchResults,
+              file.parsedTitle,
+              file.parsedYear,
+            );
 
-            if (match) {
-              insertMovie(db, {
-                title: match.title,
-                year: match.year,
-                genre: match.genre,
+            if (linkedRowId != null) {
+              if (strongMatch) {
+                enrichMovieMetadata(db, linkedRowId, {
+                  title: strongMatch.title,
+                  year: strongMatch.year,
+                  genre: strongMatch.genre,
+                  director: null,
+                  rating: strongMatch.rating,
+                  poster_url: strongMatch.poster_url,
+                  source: "tmdb",
+                  imdb_id: strongMatch.imdb_id,
+                  tmdb_id: strongMatch.tmdb_id,
+                  type: "movie",
+                });
+              }
+              results.linked++;
+              continue;
+            }
+
+            if (linkToExistingPathlessRow(db, file, strongMatch)) {
+              results.linked++;
+              continue;
+            }
+
+            if (fallbackMatch) {
+              insertAndCount({
+                title: fallbackMatch.title,
+                year: fallbackMatch.year,
+                genre: fallbackMatch.genre,
                 director: null,
-                rating: match.rating,
-                poster_url: match.poster_url,
+                rating: fallbackMatch.rating,
+                poster_url: fallbackMatch.poster_url,
                 source: "tmdb",
-                imdb_id: match.imdb_id,
-                tmdb_id: match.tmdb_id,
+                imdb_id: fallbackMatch.imdb_id,
+                tmdb_id: fallbackMatch.tmdb_id,
                 type: "movie",
                 file_path: file.filePath,
               });
-              results.added++;
             } else {
               // Add with parsed info only (no TMDb match)
-              insertMovie(db, {
+              insertAndCount({
                 title: file.parsedTitle,
                 year: file.parsedYear,
                 genre: null,
@@ -101,9 +152,12 @@ export async function POST(request: NextRequest) {
                 type: "movie",
                 file_path: file.filePath,
               });
-              results.added++;
             }
           } catch {
+            if (linkedRowId != null) {
+              results.linked++;
+              continue;
+            }
             results.failed++;
           }
         }

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { searchTmdb } from "@/lib/tmdb";
+import { searchTmdbForUi } from "@/lib/tmdb";
 
 export async function GET(request: NextRequest) {
   const query = request.nextUrl.searchParams.get("q") || "";
@@ -9,7 +9,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const results = await searchTmdb(query);
+    const results = await searchTmdbForUi(query);
     return Response.json(results);
   } catch (err) {
     const message = err instanceof Error ? err.message : "Search failed";

--- a/app/api/sync/route.ts
+++ b/app/api/sync/route.ts
@@ -1,21 +1,18 @@
 import {
+  enrichMovieMetadata,
   getDb,
+  getExistingMovieInsertTargetId,
   getSetting,
   insertMovie,
+  type MovieInput,
+  movieNeedsTmdbEnrichment,
 } from "@/lib/db";
+import { linkToExistingPathlessRow } from "@/lib/pathless-row-link";
 import { scanDirectoryGenerator } from "@/lib/scanner";
 import type { ScannedFile } from "@/lib/scanner";
 import { searchTmdb } from "@/lib/tmdb";
-import { cleanTitle } from "@/lib/utils";
-import type Database from "better-sqlite3";
+import { selectTmdbSearchCandidates } from "@/lib/tmdb-match";
 import fs from "fs";
-
-interface PathlessRow {
-  id: number;
-  title: string;
-  year: number | null;
-  tmdb_id: number | null;
-}
 
 function parseExtraFiles(extraFiles: string | null): string[] {
   if (!extraFiles) return [];
@@ -26,68 +23,6 @@ function parseExtraFiles(extraFiles: string | null): string[] {
   } catch {
     return [];
   }
-}
-
-// Try to attach a scanned file to an existing pathless DB row before
-// inserting a new one. Returns true if a row was linked.
-//
-// Match priority:
-//   1. tmdb_id (when TMDb gave us one)
-//   2. exact LOWER(title) + year IS ?  (handles NULL year correctly,
-//      unlike `year = ?` which never matches NULL)
-//   3. cleanTitle equality + year tolerance (±1, mirroring the TMDb-side
-//      tolerance), which covers wishlist rows whose stored title differs
-//      in casing/punctuation/release-tag noise from the on-disk filename
-function linkToExistingPathlessRow(
-  db: Database.Database,
-  file: ScannedFile,
-  tmdbMatch: { tmdb_id?: number | null; title?: string; year?: number | null } | null,
-): boolean {
-  const link = (id: number) => {
-    db.prepare(
-      "UPDATE movies SET file_path = ?, video_metadata = NULL, created_at = CURRENT_TIMESTAMP WHERE id = ?",
-    ).run(file.filePath, id);
-  };
-
-  if (tmdbMatch?.tmdb_id) {
-    const byTmdb = db
-      .prepare(
-        "SELECT id FROM movies WHERE tmdb_id = ? AND (file_path IS NULL OR file_path = '')",
-      )
-      .get(tmdbMatch.tmdb_id) as { id: number } | undefined;
-    if (byTmdb) {
-      link(byTmdb.id);
-      return true;
-    }
-  }
-
-  const byTitleYear = db
-    .prepare(
-      "SELECT id FROM movies WHERE LOWER(title) = LOWER(?) AND year IS ? AND (file_path IS NULL OR file_path = '')",
-    )
-    .get(file.parsedTitle, file.parsedYear) as { id: number } | undefined;
-  if (byTitleYear) {
-    link(byTitleYear.id);
-    return true;
-  }
-
-  // Normalized fallback for alt-title / punctuation-noise cases.
-  const wantTitle = cleanTitle(file.parsedTitle).toLowerCase();
-  if (!wantTitle) return false;
-  const candidates = db
-    .prepare(
-      "SELECT id, title, year, tmdb_id FROM movies WHERE file_path IS NULL OR file_path = ''",
-    )
-    .all() as PathlessRow[];
-  for (const c of candidates) {
-    if (cleanTitle(c.title).toLowerCase() !== wantTitle) continue;
-    if (file.parsedYear != null && c.year != null) {
-      if (Math.abs(c.year - file.parsedYear) > 1) continue;
-    }
-    link(c.id);
-    return true;
-  }
-  return false;
 }
 
 export async function POST() {
@@ -157,6 +92,16 @@ export async function POST() {
       let added = 0;
       let linked = 0;
       let failed = 0;
+      function insertAndCount(movie: MovieInput) {
+        const existingTargetId = getExistingMovieInsertTargetId(db, movie);
+        insertMovie(db, movie);
+        if (existingTargetId != null) {
+          linked++;
+        } else {
+          added++;
+        }
+      }
+
       for (let i = 0; i < newFiles.length; i++) {
         const file = newFiles[i];
         // Small delay to avoid TMDb rate limits (~40 req/10s)
@@ -170,7 +115,11 @@ export async function POST() {
 
         // Fast path: link the file directly to an existing pathless row
         // (e.g., from Filmweb import or wishlist). No TMDb call needed.
-        if (linkToExistingPathlessRow(db, file, null)) {
+        const linkedRowId = linkToExistingPathlessRow(db, file, null);
+        const shouldEnrichLinkedRow =
+          linkedRowId != null && movieNeedsTmdbEnrichment(db, linkedRowId);
+
+        if (linkedRowId != null && !shouldEnrichLinkedRow) {
           linked++;
           continue;
         }
@@ -180,38 +129,55 @@ export async function POST() {
             file.parsedTitle,
             file.parsedYear,
           );
-          const match =
-            searchResults.find((r) => {
-              if (file.parsedYear && r.year) {
-                return Math.abs(r.year - file.parsedYear) <= 1;
-              }
-              return true;
-            }) || searchResults[0];
+          const { strongMatch, fallbackMatch } = selectTmdbSearchCandidates(
+            searchResults,
+            file.parsedTitle,
+            file.parsedYear,
+          );
 
-          // Even with a TMDb match, prefer linking to an existing pathless
-          // row (matching by tmdb_id, exact title+year, or cleanTitle).
-          // Only insert a new row if no linkable row exists.
-          if (linkToExistingPathlessRow(db, file, match ?? null)) {
+          if (linkedRowId != null) {
+            if (strongMatch) {
+              enrichMovieMetadata(db, linkedRowId, {
+                title: strongMatch.title,
+                year: strongMatch.year,
+                genre: strongMatch.genre,
+                director: null,
+                rating: strongMatch.rating,
+                poster_url: strongMatch.poster_url,
+                source: "tmdb",
+                imdb_id: strongMatch.imdb_id,
+                tmdb_id: strongMatch.tmdb_id,
+                type: "movie",
+              });
+            }
             linked++;
             continue;
           }
 
-          if (match) {
-            insertMovie(db, {
-              title: match.title,
-              year: match.year,
-              genre: match.genre,
+          // Even with a TMDb match, prefer linking to an existing pathless
+          // row (matching by tmdb_id, exact title+year, or cleanTitle).
+          // Only insert a new row if no linkable row exists.
+          if (linkToExistingPathlessRow(db, file, strongMatch)) {
+            linked++;
+            continue;
+          }
+
+          if (fallbackMatch) {
+            insertAndCount({
+              title: fallbackMatch.title,
+              year: fallbackMatch.year,
+              genre: fallbackMatch.genre,
               director: null,
-              rating: match.rating,
-              poster_url: match.poster_url,
+              rating: fallbackMatch.rating,
+              poster_url: fallbackMatch.poster_url,
               source: "tmdb",
-              imdb_id: match.imdb_id,
-              tmdb_id: match.tmdb_id,
+              imdb_id: fallbackMatch.imdb_id,
+              tmdb_id: fallbackMatch.tmdb_id,
               type: "movie",
               file_path: file.filePath,
             });
           } else {
-            insertMovie(db, {
+            insertAndCount({
               title: file.parsedTitle,
               year: file.parsedYear,
               genre: null,
@@ -225,10 +191,13 @@ export async function POST() {
               file_path: file.filePath,
             });
           }
-          added++;
         } catch {
+          if (linkedRowId != null) {
+            linked++;
+            continue;
+          }
           // TMDb lookup failed — still add as local entry so the file isn't lost
-          insertMovie(db, {
+          insertAndCount({
             title: file.parsedTitle,
             year: file.parsedYear,
             genre: null,
@@ -241,7 +210,6 @@ export async function POST() {
             type: "movie",
             file_path: file.filePath,
           });
-          added++;
           failed++;
         }
       }

--- a/components/ImportModal.tsx
+++ b/components/ImportModal.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 interface ImportResult {
   added: number;
+  linked: number;
   skipped: number;
   failed: number;
   total: number;
@@ -247,6 +248,12 @@ export default function ImportModal({
                 <span className="w-2 h-2 rounded-full bg-green-400" />
                 <span className="text-gray-400">
                   Added: <span className="text-white">{result.added}</span>
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="w-2 h-2 rounded-full bg-sky-400" />
+                <span className="text-gray-400">
+                  Linked: <span className="text-white">{result.linked}</span>
                 </span>
               </div>
               <div className="flex items-center gap-2">

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -257,6 +257,7 @@ function enrichMissingMetadata(
   db: Database.Database,
   id: number,
   existing: {
+    year?: number | null;
     genre: string | null;
     rating: number | null;
     poster_url: string | null;
@@ -276,6 +277,7 @@ function enrichMissingMetadata(
 ): void {
   const sets: string[] = [];
   const values: (string | number | null)[] = [];
+  if ("year" in existing && existing.year == null && incoming.year != null) { sets.push("year = ?"); values.push(incoming.year); }
   if (!existing.genre && incoming.genre) { sets.push("genre = ?"); values.push(incoming.genre); }
   if (!existing.rating && incoming.rating) { sets.push("rating = ?"); values.push(incoming.rating); }
   if (!existing.poster_url && incoming.poster_url) { sets.push("poster_url = ?"); values.push(incoming.poster_url); }
@@ -295,6 +297,95 @@ function enrichMissingMetadata(
   db.prepare(`UPDATE movies SET ${sets.join(", ")} WHERE id = ?`).run(...values);
 }
 
+export function enrichMovieMetadata(
+  db: Database.Database,
+  id: number,
+  incoming: MovieInput,
+): void {
+  const existing = db
+    .prepare(
+      "SELECT year, genre, rating, poster_url, imdb_id, tmdb_id, user_rating, pl_title, filmweb_id, filmweb_url, rated_at, wishlist, description, cda_url, video_metadata FROM movies WHERE id = ?",
+    )
+    .get(id) as
+    | {
+        year: number | null;
+        genre: string | null;
+        rating: number | null;
+        poster_url: string | null;
+        imdb_id: string | null;
+        tmdb_id: number | null;
+        user_rating: number | null;
+        pl_title: string | null;
+        filmweb_id: number | null;
+        filmweb_url: string | null;
+        rated_at: string | null;
+        wishlist: number | null;
+        description: string | null;
+        cda_url: string | null;
+        video_metadata: string | null;
+      }
+    | undefined;
+  if (!existing) return;
+  enrichMissingMetadata(db, id, existing, incoming);
+}
+
+export function movieNeedsTmdbEnrichment(
+  db: Database.Database,
+  id: number,
+): boolean {
+  const existing = db
+    .prepare(
+      "SELECT year, genre, rating, poster_url, imdb_id, tmdb_id FROM movies WHERE id = ?",
+    )
+    .get(id) as
+    | {
+        year: number | null;
+        genre: string | null;
+        rating: number | null;
+        poster_url: string | null;
+        imdb_id: string | null;
+        tmdb_id: number | null;
+      }
+    | undefined;
+  if (!existing) return false;
+  return (
+    existing.year == null ||
+    existing.genre == null ||
+    existing.rating == null ||
+    existing.poster_url == null ||
+    existing.imdb_id == null ||
+    existing.tmdb_id == null
+  );
+}
+
+export function getExistingMovieInsertTargetId(
+  db: Database.Database,
+  movie: MovieInput,
+): number | null {
+  if (movie.file_path) {
+    const byFilePath = db
+      .prepare("SELECT id FROM movies WHERE file_path = ?")
+      .get(movie.file_path) as { id: number } | undefined;
+    if (byFilePath) return byFilePath.id;
+  }
+
+  if (movie.tmdb_id) {
+    const byTmdbId = db
+      .prepare("SELECT id FROM movies WHERE tmdb_id = ?")
+      .get(movie.tmdb_id) as { id: number } | undefined;
+    if (byTmdbId) return byTmdbId.id;
+  }
+
+  if (movie.title) {
+    const byTitleYear = db
+      .prepare("SELECT id FROM movies WHERE LOWER(title) = LOWER(?) AND year IS ?")
+      .get(movie.title, movie.year ?? null) as { id: number } | undefined;
+    if (byTitleYear) return byTitleYear.id;
+  }
+
+  return null;
+}
+
 export function insertMovie(db: Database.Database, movie: MovieInput): number {
   if (movie.file_path) {
     const existing = db
@@ -306,8 +397,8 @@ export function insertMovie(db: Database.Database, movie: MovieInput): number {
   // If a movie with the same tmdb_id already exists, link the file to it
   if (movie.tmdb_id) {
     const byTmdbId = db
-      .prepare("SELECT id, file_path, extra_files, genre, rating, poster_url, imdb_id, user_rating, pl_title, filmweb_id, filmweb_url, rated_at, wishlist, description, cda_url, video_metadata FROM movies WHERE tmdb_id = ?")
-      .get(movie.tmdb_id) as { id: number; file_path: string | null; extra_files: string | null; genre: string | null; rating: number | null; poster_url: string | null; imdb_id: string | null; user_rating: number | null; pl_title: string | null; filmweb_id: number | null; filmweb_url: string | null; rated_at: string | null; wishlist: number | null; description: string | null; cda_url: string | null; video_metadata: string | null } | undefined;
+      .prepare("SELECT id, year, file_path, extra_files, genre, rating, poster_url, imdb_id, user_rating, pl_title, filmweb_id, filmweb_url, rated_at, wishlist, description, cda_url, video_metadata FROM movies WHERE tmdb_id = ?")
+      .get(movie.tmdb_id) as { id: number; year: number | null; file_path: string | null; extra_files: string | null; genre: string | null; rating: number | null; poster_url: string | null; imdb_id: string | null; user_rating: number | null; pl_title: string | null; filmweb_id: number | null; filmweb_url: string | null; rated_at: string | null; wishlist: number | null; description: string | null; cda_url: string | null; video_metadata: string | null } | undefined;
     if (byTmdbId) {
       if (movie.file_path) {
         if (!byTmdbId.file_path) {
@@ -333,9 +424,9 @@ export function insertMovie(db: Database.Database, movie: MovieInput): number {
   if (movie.title) {
     const byTitleYear = db
       .prepare(
-        "SELECT id, file_path, extra_files, genre, rating, poster_url, imdb_id, tmdb_id, user_rating, pl_title, filmweb_id, filmweb_url, rated_at, wishlist, description, cda_url, video_metadata FROM movies WHERE LOWER(title) = LOWER(?) AND year IS ?",
+        "SELECT id, year, file_path, extra_files, genre, rating, poster_url, imdb_id, tmdb_id, user_rating, pl_title, filmweb_id, filmweb_url, rated_at, wishlist, description, cda_url, video_metadata FROM movies WHERE LOWER(title) = LOWER(?) AND year IS ?",
       )
-      .get(movie.title, movie.year ?? null) as { id: number; file_path: string | null; extra_files: string | null; genre: string | null; rating: number | null; poster_url: string | null; imdb_id: string | null; tmdb_id: number | null; user_rating: number | null; pl_title: string | null; filmweb_id: number | null; filmweb_url: string | null; rated_at: string | null; wishlist: number | null; description: string | null; cda_url: string | null; video_metadata: string | null } | undefined;
+      .get(movie.title, movie.year ?? null) as { id: number; year: number | null; file_path: string | null; extra_files: string | null; genre: string | null; rating: number | null; poster_url: string | null; imdb_id: string | null; tmdb_id: number | null; user_rating: number | null; pl_title: string | null; filmweb_id: number | null; filmweb_url: string | null; rated_at: string | null; wishlist: number | null; description: string | null; cda_url: string | null; video_metadata: string | null } | undefined;
     if (byTitleYear) {
       if (movie.file_path) {
         if (!byTitleYear.file_path) {

--- a/lib/hooks/useSearch.ts
+++ b/lib/hooks/useSearch.ts
@@ -1,6 +1,10 @@
 "use client";
 import { useState } from "react";
-import { getCanonicalMatchingMovie, shouldAutoSearchTmdb } from "@/lib/search";
+import {
+  getCanonicalMatchingMovie,
+  shouldAutoSearchTmdb,
+  upsertCanonicalTmdbMovie,
+} from "@/lib/search";
 import type { Movie } from "@/lib/types";
 import type { TmdbSearchResult } from "@/lib/tmdb";
 import { cleanTitle } from "@/lib/utils";
@@ -219,7 +223,7 @@ export function useSearch({
     const data = await res.json();
     setSearchOpen(false);
 
-    const newMovie: Movie = {
+    const fallbackMovie: Movie = {
       id: data.id || Date.now(),
       title: searchResult.title,
       year: searchResult.year,
@@ -237,7 +241,26 @@ export function useSearch({
       created_at: new Date().toISOString(),
       wishlist: isWishlist ? 1 : 0,
     };
-    setMovies((prev) => [newMovie, ...prev]);
+
+    let persistedMovie = fallbackMovie;
+    if (typeof data.id === "number") {
+      const movieRes = await fetch(`/api/movies/${data.id}`);
+      if (movieRes.ok) {
+        const movieData = await movieRes.json();
+        if (movieData.movie) {
+          persistedMovie = movieData.movie;
+        }
+      }
+    }
+
+    setMovies((prev) =>
+      upsertCanonicalTmdbMovie(
+        prev,
+        searchResult.tmdb_id,
+        persistedMovie,
+        persistedMovie,
+      ),
+    );
     addToast(
       isWishlist
         ? `Added "${searchResult.title}" to watchlist`

--- a/lib/pathless-row-link.ts
+++ b/lib/pathless-row-link.ts
@@ -1,0 +1,88 @@
+import { enrichMovieMetadata, type MovieInput } from "@/lib/db";
+import type { ScannedFile } from "@/lib/scanner";
+import { cleanTitle } from "@/lib/utils";
+import type Database from "better-sqlite3";
+
+interface PathlessRow {
+  id: number;
+  title: string;
+  year: number | null;
+}
+
+type PathlessRowTmdbMatch = Pick<
+  MovieInput,
+  "genre" | "imdb_id" | "poster_url" | "rating" | "tmdb_id" | "year"
+>;
+
+// Try to attach a scanned file to an existing pathless DB row before
+// inserting a new one. Returns the linked row id when a row was linked.
+//
+// Match priority:
+//   1. tmdb_id (when TMDb gave us one)
+//   2. exact LOWER(title) + year IS ? (handles NULL year correctly)
+//   3. cleanTitle equality + year tolerance (±1)
+export function linkToExistingPathlessRow(
+  db: Database.Database,
+  file: ScannedFile,
+  tmdbMatch: PathlessRowTmdbMatch | null,
+): number | null {
+  const link = (id: number) => {
+    db.prepare(
+      "UPDATE movies SET file_path = ?, video_metadata = NULL, created_at = CURRENT_TIMESTAMP WHERE id = ?",
+    ).run(file.filePath, id);
+    if (tmdbMatch) {
+      enrichMovieMetadata(db, id, {
+        title: file.parsedTitle,
+        year: tmdbMatch.year ?? file.parsedYear,
+        genre: tmdbMatch.genre ?? null,
+        director: null,
+        rating: tmdbMatch.rating ?? null,
+        poster_url: tmdbMatch.poster_url ?? null,
+        source: null,
+        imdb_id: tmdbMatch.imdb_id ?? null,
+        tmdb_id: tmdbMatch.tmdb_id ?? null,
+        type: "movie",
+      });
+    }
+    return id;
+  };
+
+  if (tmdbMatch?.tmdb_id) {
+    const byTmdb = db
+      .prepare(
+        "SELECT id FROM movies WHERE tmdb_id = ? AND (file_path IS NULL OR file_path = '')",
+      )
+      .get(tmdbMatch.tmdb_id) as { id: number } | undefined;
+    if (byTmdb) {
+      return link(byTmdb.id);
+    }
+  }
+
+  const byTitleYear = db
+    .prepare(
+      "SELECT id FROM movies WHERE LOWER(title) = LOWER(?) AND year IS ? AND (file_path IS NULL OR file_path = '')",
+    )
+    .get(file.parsedTitle, file.parsedYear) as { id: number } | undefined;
+  if (byTitleYear) {
+    return link(byTitleYear.id);
+  }
+
+  const wantTitle = cleanTitle(file.parsedTitle).toLowerCase();
+  if (!wantTitle) return null;
+
+  const candidates = db
+    .prepare(
+      "SELECT id, title, year FROM movies WHERE file_path IS NULL OR file_path = ''",
+    )
+    .all() as PathlessRow[];
+
+  for (const candidate of candidates) {
+    if (cleanTitle(candidate.title).toLowerCase() !== wantTitle) continue;
+    if (file.parsedYear != null && candidate.year != null) {
+      if (Math.abs(candidate.year - file.parsedYear) > 1) continue;
+    }
+    return link(candidate.id);
+  }
+
+  return null;
+}

--- a/lib/tmdb-match.ts
+++ b/lib/tmdb-match.ts
@@ -1,0 +1,36 @@
+import type { TmdbSearchResult } from "@/lib/tmdb";
+import { cleanTitle } from "@/lib/utils";
+
+function normalizeTitle(title: string): string {
+  return cleanTitle(title).toLowerCase();
+}
+
+export function selectTmdbSearchCandidates(
+  results: TmdbSearchResult[],
+  parsedTitle: string,
+  parsedYear: number | null,
+): {
+  strongMatch: TmdbSearchResult | null;
+  fallbackMatch: TmdbSearchResult | null;
+} {
+  const normalizedParsedTitle = normalizeTitle(parsedTitle);
+
+  const strongMatch =
+    results.find((result) => {
+      if (normalizeTitle(result.title) !== normalizedParsedTitle) {
+        return false;
+      }
+      if (parsedYear != null) {
+        if (result.year == null) {
+          return false;
+        }
+        return Math.abs(result.year - parsedYear) <= 1;
+      }
+      return true;
+    }) ?? null;
+
+  return {
+    strongMatch,
+    fallbackMatch: results[0] ?? null,
+  };
+}

--- a/lib/tmdb.ts
+++ b/lib/tmdb.ts
@@ -32,6 +32,14 @@ interface TmdbRawResult {
   genre_ids: number[];
   vote_average: number;
   poster_path: string | null;
+  popularity?: number;
+}
+
+interface TmdbRawPersonResult {
+  id: number;
+  name: string;
+  popularity: number;
+  known_for_department?: string | null;
 }
 
 interface TmdbRawCrewMember {
@@ -117,6 +125,56 @@ function mapResult(r: TmdbRawResult): TmdbSearchResult {
     tmdb_id: r.id,
     imdb_id: null,
   };
+}
+
+function getDepartmentPriority(department?: string | null): number {
+  switch (department) {
+    case "Acting":
+      return 0;
+    case "Directing":
+      return 1;
+    case "Writing":
+      return 2;
+    default:
+      return 3;
+  }
+}
+
+function getReleaseTimestamp(releaseDate: string | null): number {
+  if (!releaseDate) return 0;
+  const timestamp = Date.parse(releaseDate);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function sortPeopleResults(results: TmdbRawPersonResult[]): TmdbRawPersonResult[] {
+  return [...results].sort((a, b) => {
+    if (a.popularity !== b.popularity) {
+      return b.popularity - a.popularity;
+    }
+
+    const departmentDiff =
+      getDepartmentPriority(a.known_for_department) - getDepartmentPriority(b.known_for_department);
+    if (departmentDiff !== 0) return departmentDiff;
+
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function sortPersonFallbackMovieResults(results: TmdbRawResult[]): TmdbRawResult[] {
+  return [...results].sort((a, b) => {
+    if ((a.popularity || 0) !== (b.popularity || 0)) {
+      return (b.popularity || 0) - (a.popularity || 0);
+    }
+
+    const releaseDiff = getReleaseTimestamp(b.release_date) - getReleaseTimestamp(a.release_date);
+    if (releaseDiff !== 0) return releaseDiff;
+
+    if (a.vote_average !== b.vote_average) {
+      return b.vote_average - a.vote_average;
+    }
+
+    return a.title.localeCompare(b.title);
+  });
 }
 
 export interface TmdbSearchResult {
@@ -295,6 +353,53 @@ export async function searchTmdb(
   }
 
   return results;
+}
+
+export async function searchTmdbForUi(query: string): Promise<TmdbSearchResult[]> {
+  const movieResults = await searchTmdb(query);
+  if (movieResults.length > 0) return movieResults;
+
+  const apiKey = getApiKey();
+  const peopleRes = await fetchWithRetry(
+    `${TMDB_BASE}/search/person?query=${encodeURIComponent(query)}&language=en-US&page=1`,
+    apiKey,
+  );
+  if (!peopleRes.ok) {
+    const body = await peopleRes.text().catch(() => "");
+    console.error(`[TMDb] searchTmdbForUi person search failed: ${peopleRes.status} ${peopleRes.statusText}`, body);
+    throw new Error(`tmdb_api_error:${peopleRes.status}`);
+  }
+
+  const peopleData = (await peopleRes.json()) as { results?: TmdbRawPersonResult[] };
+  const topPeople = sortPeopleResults(peopleData.results || []).slice(0, 3);
+  if (topPeople.length === 0) return [];
+
+  const dedupedMovies = new Map<number, TmdbRawResult>();
+  for (const person of topPeople) {
+    const creditsRes = await fetchWithRetry(
+      `${TMDB_BASE}/person/${person.id}/movie_credits?language=en-US`,
+      apiKey,
+    );
+    if (!creditsRes.ok) continue;
+
+    const creditsData = (await creditsRes.json()) as {
+      cast?: TmdbRawResult[];
+      crew?: TmdbRawResult[];
+    };
+
+    for (const credit of [...(creditsData.cast || []), ...(creditsData.crew || [])]) {
+      if (!credit?.id || !credit.title) continue;
+
+      const existing = dedupedMovies.get(credit.id);
+      if (!existing || (credit.popularity || 0) > (existing.popularity || 0)) {
+        dedupedMovies.set(credit.id, credit);
+      }
+    }
+  }
+
+  return sortPersonFallbackMovieResults([...dedupedMovies.values()])
+    .slice(0, 10)
+    .map(mapResult);
 }
 
 export async function getMovieLocalized(


### PR DESCRIPTION
Closes #104

Revalidated issue #83, confirmed its implementation already exists locally on the current branch lineage, and confirmed TamTam still misreports the dedicated issue branch as already merged.

---
Implemented via TamTam from issue [#104](https://github.com/3h4x/film-pick/issues/104).