### PR TITLE
fix: Make folder import link existing Filmweb and wishlist rows instead of duplicating them

### DIFF
--- a/__tests__/import-api.test.ts
+++ b/__tests__/import-api.test.ts
@@ -383,6 +383,78 @@ describe("import API route", () => {
     expect(stored).toBe("/movies/library");
   });
 
+  // ── Pathless-row linking ────────────────────────────────────────────────────
+
+  it("counts linked=1 when a pathless row matches by title+year before TMDb search", async () => {
+    // Pre-insert a pathless Filmweb row (no file_path)
+    db.prepare(
+      "INSERT INTO movies (title, year, source, type) VALUES ('Inception', 2010, 'filmweb', 'movie')",
+    ).run();
+
+    vi.mocked(scanDirectoryGenerator).mockReturnValue(
+      (function* () {
+        yield {
+          filePath: "/movies/Inception (2010)/inception.mkv",
+          filename: "inception.mkv",
+          parsedTitle: "Inception",
+          parsedYear: 2010,
+        };
+      })() as ReturnType<typeof scanDirectoryGenerator>,
+    );
+
+    const res = await POST(makeRequest({ path: "/movies" }));
+    const lines = await readNDJSON(res);
+    const complete = lines.find((l) => l.type === "complete");
+
+    expect(complete!.linked).toBe(1);
+    expect(complete!.added).toBe(0);
+    expect(complete!.skipped).toBe(0);
+    // TMDb should not have been called since fast-path matched
+    expect(searchTmdb).not.toHaveBeenCalled();
+
+    const row = db
+      .prepare("SELECT file_path FROM movies WHERE title = 'Inception'")
+      .get() as { file_path: string };
+    expect(row.file_path).toBe("/movies/Inception (2010)/inception.mkv");
+  });
+
+  it("counts linked=1 when a pathless row matches by tmdb_id returned from TMDb", async () => {
+    // Pre-insert a pathless row with a tmdb_id (e.g., from wishlist)
+    db.prepare(
+      "INSERT INTO movies (title, year, source, tmdb_id, type) VALUES ('Dune', 2021, 'filmweb', 438631, 'movie')",
+    ).run();
+
+    vi.mocked(scanDirectoryGenerator).mockReturnValue(
+      (function* () {
+        yield {
+          filePath: "/movies/Dune Part One/dune.mkv",
+          filename: "dune.mkv",
+          parsedTitle: "Dune",
+          parsedYear: 2022,
+        };
+      })() as ReturnType<typeof scanDirectoryGenerator>,
+    );
+
+    vi.mocked(searchTmdb).mockResolvedValue([
+      {
+        title: "Dune: Part One",
+        year: 2021,
+        genre: "Sci-Fi",
+        rating: 8.0,
+        poster_url: null,
+        tmdb_id: 438631,
+        imdb_id: null,
+      },
+    ]);
+
+    const res = await POST(makeRequest({ path: "/movies" }));
+    const lines = await readNDJSON(res);
+    const complete = lines.find((l) => l.type === "complete");
+
+    expect(complete!.linked).toBe(1);
+    expect(complete!.added).toBe(0);
+  });
+
   // ── Multi-file summary ──────────────────────────────────────────────────────
 
   it("totals added + skipped + failed correctly across multiple files", async () => {

--- a/__tests__/pathless-row-link.test.ts
+++ b/__tests__/pathless-row-link.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import fs from "fs";
+import path from "path";
+import { initDb, insertMovie } from "@/lib/db";
+import { linkToExistingPathlessRow } from "@/lib/pathless-row-link";
+import type { ScannedFile } from "@/lib/scanner";
+
+const TEST_DB = path.join(__dirname, "test-pathless-row-link.db");
+
+function makeFile(overrides: Partial<ScannedFile> = {}): ScannedFile {
+  return {
+    filePath: "/movies/inception.mkv",
+    filename: "inception.mkv",
+    parsedTitle: "Inception",
+    parsedYear: 2010,
+    ...overrides,
+  };
+}
+
+describe("linkToExistingPathlessRow", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(TEST_DB);
+    initDb(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  });
+
+  it("returns false when no pathless row exists", () => {
+    const linked = linkToExistingPathlessRow(db, makeFile(), null);
+    expect(linked).toBe(false);
+  });
+
+  it("returns false when a matching row already has a file_path", () => {
+    insertMovie(db, {
+      title: "Inception",
+      year: 2010,
+      genre: null,
+      director: null,
+      rating: null,
+      poster_url: null,
+      source: "filmweb",
+      imdb_id: null,
+      tmdb_id: 27205,
+      type: "movie",
+      file_path: "/movies/other.mkv",
+    });
+    const linked = linkToExistingPathlessRow(db, makeFile(), { tmdb_id: 27205 });
+    expect(linked).toBe(false);
+  });
+
+  it("links by tmdb_id and returns true", () => {
+    const { lastInsertRowid } = db
+      .prepare(
+        "INSERT INTO movies (title, year, source, tmdb_id, type) VALUES (?, ?, 'filmweb', ?, 'movie')",
+      )
+      .run("Inception", 2010, 27205);
+    const id = Number(lastInsertRowid);
+
+    const linked = linkToExistingPathlessRow(db, makeFile(), { tmdb_id: 27205 });
+    expect(linked).toBe(true);
+
+    const row = db
+      .prepare("SELECT file_path FROM movies WHERE id = ?")
+      .get(id) as { file_path: string };
+    expect(row.file_path).toBe("/movies/inception.mkv");
+  });
+
+  it("links by exact LOWER(title) + year match when no tmdb_id provided", () => {
+    const { lastInsertRowid } = db
+      .prepare(
+        "INSERT INTO movies (title, year, source, type) VALUES (?, ?, 'filmweb', 'movie')",
+      )
+      .run("INCEPTION", 2010);
+    const id = Number(lastInsertRowid);
+
+    const linked = linkToExistingPathlessRow(db, makeFile(), null);
+    expect(linked).toBe(true);
+
+    const row = db
+      .prepare("SELECT file_path FROM movies WHERE id = ?")
+      .get(id) as { file_path: string };
+    expect(row.file_path).toBe("/movies/inception.mkv");
+  });
+
+  it("links by cleanTitle + year within ±1 when no exact match", () => {
+    const { lastInsertRowid } = db
+      .prepare(
+        "INSERT INTO movies (title, year, source, type) VALUES (?, ?, 'filmweb', 'movie')",
+      )
+      .run("Inception", 2011);
+    const id = Number(lastInsertRowid);
+
+    const linked = linkToExistingPathlessRow(db, makeFile(), null);
+    expect(linked).toBe(true);
+
+    const row = db
+      .prepare("SELECT file_path FROM movies WHERE id = ?")
+      .get(id) as { file_path: string };
+    expect(row.file_path).toBe("/movies/inception.mkv");
+  });
+
+  it("does not link when year difference exceeds ±1", () => {
+    db.prepare(
+      "INSERT INTO movies (title, year, source, type) VALUES (?, ?, 'filmweb', 'movie')",
+    ).run("Inception", 2015);
+
+    const linked = linkToExistingPathlessRow(db, makeFile(), null);
+    expect(linked).toBe(false);
+  });
+
+  it("links by tmdb_id before falling through to title match", () => {
+    // Two pathless rows: one matching title, one matching tmdb_id
+    const { lastInsertRowid: titleId } = db
+      .prepare(
+        "INSERT INTO movies (title, year, source, type) VALUES (?, ?, 'filmweb', 'movie')",
+      )
+      .run("Inception", 2010);
+    const { lastInsertRowid: tmdbId } = db
+      .prepare(
+        "INSERT INTO movies (title, year, source, tmdb_id, type) VALUES (?, ?, 'filmweb', ?, 'movie')",
+      )
+      .run("Inception", 2010, 27205);
+
+    linkToExistingPathlessRow(db, makeFile(), { tmdb_id: 27205 });
+
+    // The tmdb_id row should be linked, not the title row
+    const titleRow = db
+      .prepare("SELECT file_path FROM movies WHERE id = ?")
+      .get(Number(titleId)) as { file_path: string | null };
+    const tmdbRow = db
+      .prepare("SELECT file_path FROM movies WHERE id = ?")
+      .get(Number(tmdbId)) as { file_path: string | null };
+    expect(tmdbRow.file_path).toBe("/movies/inception.mkv");
+    expect(titleRow.file_path).toBeNull();
+  });
+
+  it("links when parsedYear is null and title matches (no year constraint)", () => {
+    const { lastInsertRowid } = db
+      .prepare(
+        "INSERT INTO movies (title, year, source, type) VALUES (?, ?, 'filmweb', 'movie')",
+      )
+      .run("Casablanca", 1942);
+    const id = Number(lastInsertRowid);
+
+    const file = makeFile({ parsedTitle: "Casablanca", parsedYear: null, filePath: "/movies/casablanca.mkv" });
+    const linked = linkToExistingPathlessRow(db, file, null);
+    expect(linked).toBe(true);
+
+    const row = db
+      .prepare("SELECT file_path FROM movies WHERE id = ?")
+      .get(id) as { file_path: string };
+    expect(row.file_path).toBe("/movies/casablanca.mkv");
+  });
+});

--- a/app/api/import/route.ts
+++ b/app/api/import/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { getDb, insertMovie, getMovieByFilePath, setSetting } from "@/lib/db";
+import { linkToExistingPathlessRow } from "@/lib/pathless-row-link";
 import { scanDirectoryGenerator } from "@/lib/scanner";
 import { searchTmdb } from "@/lib/tmdb";
 import fs from "fs";
@@ -25,7 +26,7 @@ export async function POST(request: NextRequest) {
   // Save the library path for future syncs
   setSetting(db, "library_path", dirPath);
 
-  const results = { added: 0, skipped: 0, failed: 0, total: 0 };
+  const results = { added: 0, skipped: 0, failed: 0, linked: 0, total: 0 };
 
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
@@ -56,56 +57,69 @@ export async function POST(request: NextRequest) {
         // Skip if already imported
         if (getMovieByFilePath(db, file.filePath)) {
           results.skipped++;
-        } else {
-          // Search TMDb for metadata
-          try {
-            const searchResults = await searchTmdb(
-              file.parsedTitle,
-              file.parsedYear,
-            );
-            const match =
-              searchResults.find((r) => {
-                if (file.parsedYear && r.year) {
-                  return Math.abs(r.year - file.parsedYear) <= 1;
-                }
-                return true;
-              }) || searchResults[0];
+          continue;
+        }
 
-            if (match) {
-              insertMovie(db, {
-                title: match.title,
-                year: match.year,
-                genre: match.genre,
-                director: null,
-                rating: match.rating,
-                poster_url: match.poster_url,
-                source: "tmdb",
-                imdb_id: match.imdb_id,
-                tmdb_id: match.tmdb_id,
-                type: "movie",
-                file_path: file.filePath,
-              });
-              results.added++;
-            } else {
-              // Add with parsed info only (no TMDb match)
-              insertMovie(db, {
-                title: file.parsedTitle,
-                year: file.parsedYear,
-                genre: null,
-                director: null,
-                rating: null,
-                poster_url: null,
-                source: "local",
-                imdb_id: null,
-                tmdb_id: null,
-                type: "movie",
-                file_path: file.filePath,
-              });
-              results.added++;
-            }
-          } catch {
-            results.failed++;
+        // Fast path: link to an existing pathless row (Filmweb import or wishlist)
+        if (linkToExistingPathlessRow(db, file, null)) {
+          results.linked++;
+          continue;
+        }
+
+        // Search TMDb for metadata
+        try {
+          const searchResults = await searchTmdb(
+            file.parsedTitle,
+            file.parsedYear,
+          );
+          const match =
+            searchResults.find((r) => {
+              if (file.parsedYear && r.year) {
+                return Math.abs(r.year - file.parsedYear) <= 1;
+              }
+              return true;
+            }) || searchResults[0];
+
+          // Prefer linking to an existing pathless row matching the TMDb result.
+          if (linkToExistingPathlessRow(db, file, match ?? null)) {
+            results.linked++;
+            continue;
           }
+
+          if (match) {
+            insertMovie(db, {
+              title: match.title,
+              year: match.year,
+              genre: match.genre,
+              director: null,
+              rating: match.rating,
+              poster_url: match.poster_url,
+              source: "tmdb",
+              imdb_id: match.imdb_id,
+              tmdb_id: match.tmdb_id,
+              type: "movie",
+              file_path: file.filePath,
+            });
+            results.added++;
+          } else {
+            // Add with parsed info only (no TMDb match)
+            insertMovie(db, {
+              title: file.parsedTitle,
+              year: file.parsedYear,
+              genre: null,
+              director: null,
+              rating: null,
+              poster_url: null,
+              source: "local",
+              imdb_id: null,
+              tmdb_id: null,
+              type: "movie",
+              file_path: file.filePath,
+            });
+            results.added++;
+          }
+        } catch {
+          results.failed++;
         }
       }
 

--- a/app/api/sync/route.ts
+++ b/app/api/sync/route.ts
@@ -3,19 +3,11 @@ import {
   getSetting,
   insertMovie,
 } from "@/lib/db";
+import { linkToExistingPathlessRow } from "@/lib/pathless-row-link";
 import { scanDirectoryGenerator } from "@/lib/scanner";
 import type { ScannedFile } from "@/lib/scanner";
 import { searchTmdb } from "@/lib/tmdb";
-import { cleanTitle } from "@/lib/utils";
-import type Database from "better-sqlite3";
 import fs from "fs";
-
-interface PathlessRow {
-  id: number;
-  title: string;
-  year: number | null;
-  tmdb_id: number | null;
-}
 
 function parseExtraFiles(extraFiles: string | null): string[] {
   if (!extraFiles) return [];
@@ -28,67 +20,6 @@ function parseExtraFiles(extraFiles: string | null): string[] {
   }
 }
 
-// Try to attach a scanned file to an existing pathless DB row before
-// inserting a new one. Returns true if a row was linked.
-//
-// Match priority:
-//   1. tmdb_id (when TMDb gave us one)
-//   2. exact LOWER(title) + year IS ?  (handles NULL year correctly,
-//      unlike `year = ?` which never matches NULL)
-//   3. cleanTitle equality + year tolerance (±1, mirroring the TMDb-side
-//      tolerance), which covers wishlist rows whose stored title differs
-//      in casing/punctuation/release-tag noise from the on-disk filename
-function linkToExistingPathlessRow(
-  db: Database.Database,
-  file: ScannedFile,
-  tmdbMatch: { tmdb_id?: number | null; title?: string; year?: number | null } | null,
-): boolean {
-  const link = (id: number) => {
-    db.prepare(
-      "UPDATE movies SET file_path = ?, video_metadata = NULL, created_at = CURRENT_TIMESTAMP WHERE id = ?",
-    ).run(file.filePath, id);
-  };
-
-  if (tmdbMatch?.tmdb_id) {
-    const byTmdb = db
-      .prepare(
-        "SELECT id FROM movies WHERE tmdb_id = ? AND (file_path IS NULL OR file_path = '')",
-      )
-      .get(tmdbMatch.tmdb_id) as { id: number } | undefined;
-    if (byTmdb) {
-      link(byTmdb.id);
-      return true;
-    }
-  }
-
-  const byTitleYear = db
-    .prepare(
-      "SELECT id FROM movies WHERE LOWER(title) = LOWER(?) AND year IS ? AND (file_path IS NULL OR file_path = '')",
-    )
-    .get(file.parsedTitle, file.parsedYear) as { id: number } | undefined;
-  if (byTitleYear) {
-    link(byTitleYear.id);
-    return true;
-  }
-
-  // Normalized fallback for alt-title / punctuation-noise cases.
-  const wantTitle = cleanTitle(file.parsedTitle).toLowerCase();
-  if (!wantTitle) return false;
-  const candidates = db
-    .prepare(
-      "SELECT id, title, year, tmdb_id FROM movies WHERE file_path IS NULL OR file_path = ''",
-    )
-    .all() as PathlessRow[];
-  for (const c of candidates) {
-    if (cleanTitle(c.title).toLowerCase() !== wantTitle) continue;
-    if (file.parsedYear != null && c.year != null) {
-      if (Math.abs(c.year - file.parsedYear) > 1) continue;
-    }
-    link(c.id);
-    return true;
-  }
-  return false;
-}
 
 export async function POST() {
   const db = getDb();

--- a/lib/pathless-row-link.ts
+++ b/lib/pathless-row-link.ts
@@ -1,0 +1,74 @@
+import type { ScannedFile } from "@/lib/scanner";
+import { cleanTitle } from "@/lib/utils";
+import type Database from "better-sqlite3";
+
+interface PathlessRow {
+  id: number;
+  title: string;
+  year: number | null;
+}
+
+type PathlessRowTmdbMatch = {
+  tmdb_id?: number | null;
+} | null;
+
+// Try to attach a scanned file to an existing pathless DB row before
+// inserting a new one. Returns true if a row was linked.
+//
+// Match priority:
+//   1. tmdb_id (when TMDb gave us one)
+//   2. exact LOWER(title) + year IS ?
+//   3. cleanTitle equality + year tolerance (±1)
+export function linkToExistingPathlessRow(
+  db: Database.Database,
+  file: ScannedFile,
+  tmdbMatch: PathlessRowTmdbMatch,
+): boolean {
+  const link = (id: number) => {
+    db.prepare(
+      "UPDATE movies SET file_path = ?, video_metadata = NULL, created_at = CURRENT_TIMESTAMP WHERE id = ?",
+    ).run(file.filePath, id);
+  };
+
+  if (tmdbMatch?.tmdb_id) {
+    const byTmdb = db
+      .prepare(
+        "SELECT id FROM movies WHERE tmdb_id = ? AND (file_path IS NULL OR file_path = '')",
+      )
+      .get(tmdbMatch.tmdb_id) as { id: number } | undefined;
+    if (byTmdb) {
+      link(byTmdb.id);
+      return true;
+    }
+  }
+
+  const byTitleYear = db
+    .prepare(
+      "SELECT id FROM movies WHERE LOWER(title) = LOWER(?) AND year IS ? AND (file_path IS NULL OR file_path = '')",
+    )
+    .get(file.parsedTitle, file.parsedYear) as { id: number } | undefined;
+  if (byTitleYear) {
+    link(byTitleYear.id);
+    return true;
+  }
+
+  const wantTitle = cleanTitle(file.parsedTitle).toLowerCase();
+  if (!wantTitle) return false;
+
+  const candidates = db
+    .prepare(
+      "SELECT id, title, year FROM movies WHERE file_path IS NULL OR file_path = ''",
+    )
+    .all() as PathlessRow[];
+
+  for (const candidate of candidates) {
+    if (cleanTitle(candidate.title).toLowerCase() !== wantTitle) continue;
+    if (file.parsedYear != null && candidate.year != null) {
+      if (Math.abs(candidate.year - file.parsedYear) > 1) continue;
+    }
+    link(candidate.id);
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Closes #83

Implemented via TamTam from issue [#83](https://github.com/3h4x/film-pick/issues/83).