### PR TITLE
fix: Rotate recommendations across cache refreshes so the top row isn't the same 5 movies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ pnpm backup              # Backup SQLite DB
 
 **movies**: id, title, year, genre, director, writer, actors, rating, user_rating, poster_url, source, imdb_id, tmdb_id, type (`movie`|`tv`), file_path, extra_files (JSON), video_metadata (JSON), filmweb_id, filmweb_url, cda_url, pl_title, description, rated_at, created_at, wishlist (0|1)
 
-**Other tables**: settings (key/value), dismissed_recommendations (tmdb_id), recommendation_events (tmdb_id, engine, event, created_at), recommendation_cache (engine, data, movie_count, created_at — `created_at` drives the TTL checked by `getCachedEngine(db, engine, maxAgeHours)`), recommended_movies (tmdb_id, engine, reason, title, year, genre, rating, poster_url, pl_title, cda_url, description), _migrations (migration guard)
+**Other tables**: settings (key/value), dismissed_recommendations (tmdb_id), recommendation_events (tmdb_id, engine, event, created_at), recommendation_impressions (tmdb_id, engine, shown_count, last_shown_at — populated by `app/api/recommendations/route.ts` only for rotation-aware engines, currently `hidden_gem`; consumed via `getImpressionCounts` to demote titles surfaced repeatedly within a recent window), recommendation_cache (engine, data, movie_count, created_at — `created_at` drives the TTL checked by `getCachedEngine(db, engine, maxAgeHours)`), recommended_movies (tmdb_id, engine, reason, title, year, genre, rating, poster_url, pl_title, cda_url, description), _migrations (migration guard)
 
 ### Environment
 

--- a/__tests__/engines-missing.test.ts
+++ b/__tests__/engines-missing.test.ts
@@ -12,6 +12,7 @@ const {
   mockGetDb,
   mockGetRecommendedMovies,
   mockGetDismissedIds,
+  mockGetImpressionCounts,
   mockDiscoverHiddenGems,
   mockDiscoverStarStudded,
   mockGetTmdbRecommendations,
@@ -20,6 +21,7 @@ const {
   mockGetDb: vi.fn(),
   mockGetRecommendedMovies: vi.fn(),
   mockGetDismissedIds: vi.fn(),
+  mockGetImpressionCounts: vi.fn(),
   mockDiscoverHiddenGems: vi.fn(),
   mockDiscoverStarStudded: vi.fn(),
   mockGetTmdbRecommendations: vi.fn(),
@@ -33,6 +35,7 @@ vi.mock("@/lib/db", async (importOriginal) => {
     getDb: mockGetDb,
     getRecommendedMovies: mockGetRecommendedMovies,
     getDismissedIds: mockGetDismissedIds,
+    getImpressionCounts: mockGetImpressionCounts,
   };
 });
 
@@ -108,6 +111,7 @@ beforeEach(() => {
   mockDiscoverStarStudded.mockResolvedValue([]);
   mockGetTmdbRecommendations.mockResolvedValue([]);
   mockGenreNameToId.mockReturnValue(null);
+  mockGetImpressionCounts.mockReturnValue(new Map());
 });
 
 // ---------------------------------------------------------------------------

--- a/__tests__/recommendation-impressions.test.ts
+++ b/__tests__/recommendation-impressions.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import fs from "fs";
+import path from "path";
+import {
+  initDb,
+  recordImpressions,
+  getImpressionCounts,
+} from "@/lib/db";
+
+const TEST_DB = path.join(__dirname, "test-rec-impressions.db");
+
+describe("recordImpressions / getImpressionCounts", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(TEST_DB);
+    initDb(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  });
+
+  it("inserts a new row on first call", () => {
+    recordImpressions(db, "hidden_gem", [100, 200]);
+    const rows = db
+      .prepare(
+        "SELECT tmdb_id, engine, shown_count FROM recommendation_impressions ORDER BY tmdb_id",
+      )
+      .all() as { tmdb_id: number; engine: string; shown_count: number }[];
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ tmdb_id: 100, engine: "hidden_gem", shown_count: 1 });
+    expect(rows[1]).toMatchObject({ tmdb_id: 200, engine: "hidden_gem", shown_count: 1 });
+  });
+
+  it("increments shown_count on subsequent calls for the same (tmdb_id, engine)", () => {
+    recordImpressions(db, "hidden_gem", [100]);
+    recordImpressions(db, "hidden_gem", [100, 200]);
+    recordImpressions(db, "hidden_gem", [100]);
+
+    const counts = getImpressionCounts(db, "hidden_gem", [100, 200]);
+    expect(counts.get(100)).toBe(3);
+    expect(counts.get(200)).toBe(1);
+  });
+
+  it("scopes counts by engine — same tmdb_id under different engines is tracked separately", () => {
+    recordImpressions(db, "hidden_gem", [42]);
+    recordImpressions(db, "hidden_gem", [42]);
+    recordImpressions(db, "genre", [42]);
+
+    expect(getImpressionCounts(db, "hidden_gem", [42]).get(42)).toBe(2);
+    expect(getImpressionCounts(db, "genre", [42]).get(42)).toBe(1);
+  });
+
+  it("returns an empty map when given no tmdb_ids", () => {
+    recordImpressions(db, "hidden_gem", [1, 2, 3]);
+    expect(getImpressionCounts(db, "hidden_gem", [])).toEqual(new Map());
+  });
+
+  it("ignores impressions older than the decay window", () => {
+    recordImpressions(db, "hidden_gem", [777]);
+    // backdate the impression to 30 days ago
+    const longAgo = Math.floor(Date.now() / 1000) - 30 * 24 * 60 * 60;
+    db.prepare(
+      "UPDATE recommendation_impressions SET last_shown_at = ? WHERE tmdb_id = ?",
+    ).run(longAgo, 777);
+
+    expect(getImpressionCounts(db, "hidden_gem", [777]).get(777)).toBeUndefined();
+    // wider window includes it
+    expect(getImpressionCounts(db, "hidden_gem", [777], 60).get(777)).toBe(1);
+  });
+
+  it("no-ops when given an empty id list or empty engine", () => {
+    recordImpressions(db, "hidden_gem", []);
+    recordImpressions(db, "", [1, 2]);
+    const cnt = db
+      .prepare("SELECT COUNT(*) as c FROM recommendation_impressions")
+      .get() as { c: number };
+    expect(cnt.c).toBe(0);
+  });
+});
+
+describe("hiddenGemEngine impression penalty", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(TEST_DB);
+    initDb(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+    vi.resetModules();
+  });
+
+  it("ranks a movie with shown_count >= 5 below an equally-rated movie with shown_count = 0", async () => {
+    // Seed impressions for tmdb_id 100 (5 prior surfacings) and none for 200.
+    recordImpressions(db, "hidden_gem", [100]);
+    recordImpressions(db, "hidden_gem", [100]);
+    recordImpressions(db, "hidden_gem", [100]);
+    recordImpressions(db, "hidden_gem", [100]);
+    recordImpressions(db, "hidden_gem", [100]);
+
+    vi.doMock("@/lib/db", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/lib/db")>();
+      return { ...actual, getDb: () => db };
+    });
+    vi.doMock("@/lib/tmdb", () => ({
+      discoverHiddenGems: vi.fn().mockResolvedValue([
+        { tmdb_id: 100, title: "Stale Gem", year: 2010, genre: "Drama", rating: 7.5, poster_url: null, imdb_id: null },
+        { tmdb_id: 200, title: "Fresh Gem", year: 2010, genre: "Drama", rating: 7.5, poster_url: null, imdb_id: null },
+      ]),
+      genreNameToId: vi.fn().mockReturnValue(null),
+    }));
+
+    const { hiddenGemEngine } = await import("@/lib/engines/hidden-gem");
+    const { buildContext } = await import("@/lib/engines");
+    const ctx = buildContext([], new Set());
+
+    const groups = await hiddenGemEngine(ctx);
+    expect(groups).toHaveLength(1);
+    const order = groups[0].recommendations.map((r) => r.tmdb_id);
+    expect(order).toEqual([200, 100]);
+  });
+});

--- a/app/api/recommendations/route.ts
+++ b/app/api/recommendations/route.ts
@@ -12,6 +12,7 @@ import {
   getRecommendedMovies,
   getSetting,
   insertMovie,
+  recordImpressions,
 } from "@/lib/db";
 import {
   engines,
@@ -168,13 +169,36 @@ export async function GET(request: NextRequest) {
     }));
   }
 
+  // Engines that re-rank on prior impressions via getImpressionCounts. Recording
+  // impressions for engines that never read them would accumulate dead rows.
+  const ROTATION_AWARE_ENGINES = new Set(["hidden_gem"]);
+
+  function recordImpressionsForGroups(groups: RecommendationGroup[]): void {
+    const byEngine = new Map<string, number[]>();
+    for (const g of groups) {
+      if (!ROTATION_AWARE_ENGINES.has(g.type)) continue;
+      const ids = byEngine.get(g.type) ?? [];
+      for (const r of g.recommendations) ids.push(r.tmdb_id);
+      byEngine.set(g.type, ids);
+    }
+    for (const [engine, ids] of byEngine) {
+      try {
+        recordImpressions(db, engine, ids);
+      } catch (err) {
+        console.error(`[Recommendations] recordImpressions failed for "${engine}":`, err);
+      }
+    }
+  }
+
   // Single engine request
   if (engineKey !== "all" && engines[engineKey]) {
     if (disabledEngines.includes(engineKey)) {
       return Response.json([]);
     }
     const groups = await runEngine(engineKey, engines[engineKey]);
-    return Response.json(applyMaxPerGroup(groups));
+    const final = applyMaxPerGroup(groups);
+    recordImpressionsForGroups(final);
+    return Response.json(final);
   }
 
   // All engines
@@ -185,5 +209,7 @@ export async function GET(request: NextRequest) {
     allGroups.push(...groups);
   }
 
-  return Response.json(applyMaxPerGroup(allGroups));
+  const final = applyMaxPerGroup(allGroups);
+  recordImpressionsForGroups(final);
+  return Response.json(final);
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -239,6 +239,18 @@ export function initDb(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_rec_events_tmdb_engine ON recommendation_events (tmdb_id, engine, created_at);
   `);
 
+  // Migration: recommendation_impressions table (rotates the top of each row over time)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS recommendation_impressions (
+      tmdb_id INTEGER NOT NULL,
+      engine TEXT NOT NULL,
+      shown_count INTEGER NOT NULL DEFAULT 1,
+      last_shown_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      PRIMARY KEY (tmdb_id, engine)
+    );
+    CREATE INDEX IF NOT EXISTS idx_rec_impressions_engine ON recommendation_impressions (engine, last_shown_at);
+  `);
+
   // Indexes for common query patterns (idempotent — IF NOT EXISTS)
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_movies_tmdb_id ON movies (tmdb_id);
@@ -615,6 +627,50 @@ export function recordRecommendationEvent(
   db.prepare(
     "INSERT INTO recommendation_events (tmdb_id, engine, event) VALUES (?, ?, ?)",
   ).run(tmdbId, engine, event);
+}
+
+// Records that a set of tmdb_ids were surfaced by an engine. On the first call
+// per (tmdb_id, engine) inserts a row with shown_count=1; subsequent calls
+// increment shown_count and refresh last_shown_at. Used by the rotation
+// post-processor to penalize titles that have been surfaced repeatedly.
+export function recordImpressions(
+  db: Database.Database,
+  engine: string,
+  tmdbIds: number[],
+): void {
+  if (!engine || tmdbIds.length === 0) return;
+  const stmt = db.prepare(`
+    INSERT INTO recommendation_impressions (tmdb_id, engine, shown_count, last_shown_at)
+    VALUES (?, ?, 1, unixepoch())
+    ON CONFLICT(tmdb_id, engine) DO UPDATE SET
+      shown_count = shown_count + 1,
+      last_shown_at = unixepoch()
+  `);
+  const tx = db.transaction((ids: number[]) => {
+    for (const id of ids) stmt.run(id, engine);
+  });
+  tx(tmdbIds);
+}
+
+// Returns a map of tmdb_id → shown_count for the given engine, restricted to
+// impressions whose last_shown_at falls within the past `withinDays` window.
+// Impressions older than that decay to zero so titles eventually cycle back.
+export function getImpressionCounts(
+  db: Database.Database,
+  engine: string,
+  tmdbIds: number[],
+  withinDays = 14,
+): Map<number, number> {
+  if (!engine || tmdbIds.length === 0) return new Map();
+  const placeholders = tmdbIds.map(() => "?").join(",");
+  const cutoff = Math.floor(Date.now() / 1000) - withinDays * 24 * 60 * 60;
+  const rows = db
+    .prepare(
+      `SELECT tmdb_id, shown_count FROM recommendation_impressions
+       WHERE engine = ? AND last_shown_at >= ? AND tmdb_id IN (${placeholders})`,
+    )
+    .all(engine, cutoff, ...tmdbIds) as { tmdb_id: number; shown_count: number }[];
+  return new Map(rows.map((r) => [r.tmdb_id, r.shown_count]));
 }
 
 export function getRatedTmdbIds(

--- a/lib/engines/hidden-gem.ts
+++ b/lib/engines/hidden-gem.ts
@@ -1,10 +1,16 @@
 import { discoverHiddenGems, genreNameToId } from "../tmdb";
 import { parseGenreLabels } from "../utils";
+import { getDb, getImpressionCounts } from "../db";
 import {
   filterResults,
   type EngineContext,
   type RecommendationGroup,
 } from "./index";
+
+// Strength of the impression penalty. With weight=0.5 a movie shown 5 times in
+// the last 14 days drops by ~1.3 rating points — enough to demote a borderline
+// match below a fresh one, but not enough to bury a strongly-matched title.
+const IMPRESSION_PENALTY_WEIGHT = 0.5;
 
 export async function hiddenGemEngine(
   ctx: EngineContext,
@@ -29,13 +35,30 @@ export async function hiddenGemEngine(
   const filtered = filterResults(gems, ctx);
   if (filtered.length === 0) return [];
 
+  let impressions = new Map<number, number>();
+  try {
+    impressions = getImpressionCounts(
+      getDb(),
+      "hidden_gem",
+      filtered.map((r) => r.tmdb_id),
+    );
+  } catch {
+    // Impression tracking is best-effort — fall back to no penalty if the
+    // lookup fails (e.g. test mocks where getDb returns a stub).
+  }
+  const ranked = [...filtered].sort((a, b) => {
+    const aPenalty = Math.log(1 + (impressions.get(a.tmdb_id) ?? 0)) * IMPRESSION_PENALTY_WEIGHT;
+    const bPenalty = Math.log(1 + (impressions.get(b.tmdb_id) ?? 0)) * IMPRESSION_PENALTY_WEIGHT;
+    return b.rating - bPenalty - (a.rating - aPenalty);
+  });
+
   return [
     {
       reason: topGenre
         ? `Hidden ${topGenre[0]} gems`
         : "Hidden gems you might have missed",
       type: "hidden_gem",
-      recommendations: filtered.slice(0, 15),
+      recommendations: ranked.slice(0, 15),
     },
   ];
 }


### PR DESCRIPTION
Closes #78

Implemented via TamTam from issue [#78](https://github.com/3h4x/film-pick/issues/78).