### PR TITLE
fix: Add recommendation trace data so bad suggestions can be debugged

### DIFF
--- a/__tests__/db.test.ts
+++ b/__tests__/db.test.ts
@@ -133,6 +133,36 @@ describe("recommendation cache", () => {
     expect(result).toEqual(data);
   });
 
+  it("preserves recommendation trace in cached engine JSON", () => {
+    const data = [{
+      reason: "Because you loved Inception",
+      type: "movie",
+      recommendations: [{
+        tmdb_id: 329865,
+        title: "Arrival",
+        year: 2016,
+        genre: "Sci-Fi",
+        rating: 7.9,
+        poster_url: null,
+        imdb_id: null,
+        trace: {
+          engine: "movie",
+          source: "live_tmdb",
+          seedKind: "movie",
+          seedTmdbId: 27205,
+          seedTitle: "Inception",
+        },
+      }],
+    }];
+    setCachedEngine(db, "movie", data, 5);
+    const result = getCachedEngine<typeof data[number]>(db, "movie", 5);
+    expect(result?.[0].recommendations[0].trace).toMatchObject({
+      engine: "movie",
+      source: "live_tmdb",
+      seedTmdbId: 27205,
+    });
+  });
+
   it("returns null when movie count differs from cached count", () => {
     setCachedEngine(db, "genre", [{ tmdb_id: 1, title: "Test" }], 5);
     expect(getCachedEngine(db, "genre", 10)).toBeNull();
@@ -420,6 +450,25 @@ describe("recommended movies", () => {
     expect(movies[0].engine).toBe("genre");
     expect(movies[0].reason).toBe("Because you love Sci-Fi");
     expect(movies[0].tmdb_id).toBe(329865);
+  });
+
+  it("saves and retrieves recommendation trace from recommended_movies", () => {
+    saveRecommendedMovies(db, "genre", "Because you love Sci-Fi", [{
+      ...sampleMovie,
+      trace: {
+        engine: "genre",
+        source: "live_tmdb",
+        seedKind: "genre",
+        seedId: 878,
+        seedName: "Sci-Fi",
+      },
+    }]);
+    const movies = getRecommendedMovies(db, "genre");
+    expect(movies[0].trace).toMatchObject({
+      engine: "genre",
+      source: "live_tmdb",
+      seedName: "Sci-Fi",
+    });
   });
 
   it("retrieves recommended movies filtered by engine", () => {
@@ -922,6 +971,33 @@ describe("database migrations on existing schema", () => {
 
     const cols = (db.pragma("table_info(recommended_movies)") as { name: string }[]).map((c) => c.name);
     expect(cols).toContain("description");
+  });
+
+  it("adds trace column to recommended_movies when missing", () => {
+    db = new Database(MIGRATION_DB);
+    db.exec(ORIGINAL_MOVIES_SCHEMA);
+    db.exec(`
+      CREATE TABLE recommended_movies (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        tmdb_id INTEGER NOT NULL,
+        engine TEXT NOT NULL,
+        reason TEXT NOT NULL,
+        title TEXT NOT NULL,
+        year INTEGER,
+        genre TEXT,
+        rating REAL,
+        poster_url TEXT,
+        pl_title TEXT,
+        cda_url TEXT,
+        description TEXT,
+        UNIQUE(tmdb_id, engine)
+      );
+    `);
+
+    initDb(db);
+
+    const cols = (db.pragma("table_info(recommended_movies)") as { name: string }[]).map((c) => c.name);
+    expect(cols).toContain("trace");
   });
 
   it("preserves existing movie data through migrations", () => {

--- a/__tests__/engines-cda.test.ts
+++ b/__tests__/engines-cda.test.ts
@@ -99,6 +99,11 @@ describe("cdaEngine", () => {
     const types = result.map((g) => g.reason);
     expect(types).toContain("Science Fiction on CDA");
     expect(types).toContain("Drama on CDA");
+    expect(result[0].recommendations[0].trace).toMatchObject({
+      engine: "cda",
+      source: "recommended_movies",
+      seedKind: "cda",
+    });
   });
 
   it("filters out movies already in library by tmdb_id", async () => {

--- a/__tests__/engines-index.test.ts
+++ b/__tests__/engines-index.test.ts
@@ -418,8 +418,9 @@ describe("buildContext", () => {
 // ---------------------------------------------------------------------------
 
 function makeCdaMovie(overrides: Partial<RecommendedMovie> & { tmdb_id: number; title: string }): RecommendedMovie {
+  const { trace, ...rest } = overrides;
   return {
-    id: overrides.tmdb_id,
+    id: rest.tmdb_id,
     engine: "cda",
     reason: "cda",
     year: 2020,
@@ -430,7 +431,8 @@ function makeCdaMovie(overrides: Partial<RecommendedMovie> & { tmdb_id: number; 
     cda_url: "https://cda.pl/video/default",
     description: null,
     created_at: "2026-01-01",
-    ...overrides,
+    ...rest,
+    trace: trace ?? null,
   };
 }
 

--- a/__tests__/engines-missing.test.ts
+++ b/__tests__/engines-missing.test.ts
@@ -86,6 +86,7 @@ function makeResult(
 }
 
 function makeRecommendedMovie(overrides: Partial<RecommendedMovie> & { tmdb_id: number; title: string }): RecommendedMovie {
+  const { trace, ...rest } = overrides;
   return {
     id: 1,
     engine: "cda",
@@ -98,7 +99,8 @@ function makeRecommendedMovie(overrides: Partial<RecommendedMovie> & { tmdb_id: 
     cda_url: "https://cda.pl/video/test",
     description: null,
     created_at: "2026-01-01",
-    ...overrides,
+    ...rest,
+    trace: trace ?? null,
   };
 }
 

--- a/__tests__/engines-movie-actor-director.test.ts
+++ b/__tests__/engines-movie-actor-director.test.ts
@@ -90,6 +90,13 @@ describe("movieEngine", () => {
     expect(result[0].reason).toContain("Inception");
     expect(result[0].type).toBe("movie");
     expect(result[0].recommendations[0].title).toBe("Arrival");
+    expect(result[0].recommendations[0].trace).toMatchObject({
+      engine: "movie",
+      source: "live_tmdb",
+      seedKind: "movie",
+      seedTmdbId: 27205,
+      seedTitle: "Inception",
+    });
   });
 
   it("merges similar results with recommendations, deduplicating by tmdb_id", async () => {
@@ -229,6 +236,13 @@ describe("actorEngine", () => {
     expect(result.length).toBeGreaterThanOrEqual(1);
     expect(result[0].reason).toContain("Tom Hanks");
     expect(result[0].type).toBe("actor");
+    expect(result[0].recommendations[0].trace).toMatchObject({
+      engine: "actor",
+      source: "live_tmdb",
+      seedKind: "actor",
+      seedId: actorId,
+      seedName: "Tom Hanks",
+    });
   });
 
   it("respects actor_min_appearances=1 — includes actors with single appearance", async () => {
@@ -319,6 +333,13 @@ describe("directorEngine", () => {
     expect(result.length).toBeGreaterThanOrEqual(1);
     expect(result[0].reason).toContain("Christopher Nolan");
     expect(result[0].type).toBe("director");
+    expect(result[0].recommendations[0].trace).toMatchObject({
+      engine: "director",
+      source: "live_tmdb",
+      seedKind: "director",
+      seedId: dirId,
+      seedName: "Christopher Nolan",
+    });
   });
 
   it("respects director_min_films=1 — includes director with single film", async () => {

--- a/__tests__/recommendations-api.test.ts
+++ b/__tests__/recommendations-api.test.ts
@@ -36,6 +36,7 @@ vi.mock("@/lib/engines", () => ({
   })),
   // Return results unchanged so we can assert on raw engine output.
   enrichWithCda: vi.fn((results: TmdbSearchResult[]) => results),
+  overrideTraceSource: vi.fn((groups: RecommendationGroup[]) => groups),
 }));
 
 // Patch only getDb; every other DB function runs against the real in-memory DB.

--- a/__tests__/responsive-action-visibility.test.tsx
+++ b/__tests__/responsive-action-visibility.test.tsx
@@ -29,6 +29,17 @@ const rec: TmdbSearchResult = {
   imdb_id: "tt0113277",
 };
 
+const tracedRec: TmdbSearchResult = {
+  ...rec,
+  trace: {
+    engine: "movie",
+    source: "live_tmdb",
+    seedKind: "movie",
+    seedTmdbId: 27205,
+    seedTitle: "Inception",
+  },
+};
+
 const moodGroups: RecommendationGroup[] = [
   {
     reason: "For tense nights",
@@ -110,6 +121,23 @@ describe("responsive action visibility", () => {
     expect(html).toContain(HOVER_REVEAL_REC_CLASS);
     expect(html).toContain("Show actions");
     expect(html).not.toContain("md:[@media(hover:hover)]");
+  });
+
+  it("keeps trace controls away from grouped recommendation rating badges", () => {
+    const html = renderToStaticMarkup(
+      <RecommendationRow
+        reason="Because you liked crime"
+        type="movie"
+        recommendations={[tracedRec]}
+        onAction={vi.fn()}
+        onClickMovie={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("Trace");
+    expect(html).toContain("★ 8.3");
+    expect(html).toContain("absolute right-2 top-2 z-20");
+    expect(html).not.toContain("absolute left-2 top-2 z-20");
   });
 
   it("keeps mood recommendation actions hover-gated by input capability instead of md width", () => {

--- a/app/api/recommendations/route.ts
+++ b/app/api/recommendations/route.ts
@@ -19,6 +19,7 @@ import {
   buildContext,
   getCdaLookup,
   enrichWithCda,
+  overrideTraceSource,
   type RecommendationGroup,
   type RecConfig,
 } from "@/lib/engines";
@@ -147,7 +148,12 @@ export async function GET(request: NextRequest) {
       const cached = getCachedEngine(db, key, movieCount);
       if (cached) {
         return addCdaUrls(
-          filterExcluded(enrichFromDb(cached as RecommendationGroup[], key)),
+          filterExcluded(
+            overrideTraceSource(
+              enrichFromDb(cached as RecommendationGroup[], key),
+              "recommendation_cache",
+            ),
+          ),
         );
       }
 

--- a/components/RecommendationRow.tsx
+++ b/components/RecommendationRow.tsx
@@ -130,7 +130,7 @@ export default function RecommendationRow({
               onClick={() => onClickMovie(r, type)}
             />
             {r.trace ? (
-              <details className="absolute left-2 top-2 z-20 max-w-[calc(100%-1rem)]">
+              <details className="absolute right-2 top-2 z-20 max-w-[calc(100%-1rem)]">
                 <summary className="cursor-pointer list-none rounded-md bg-black/70 px-2 py-1 text-[10px] font-medium uppercase tracking-[0.18em] text-cyan-200 backdrop-blur-sm">
                   Trace
                 </summary>

--- a/components/RecommendationRow.tsx
+++ b/components/RecommendationRow.tsx
@@ -44,6 +44,11 @@ const TYPE_ICONS: Record<string, string> = {
   random: "🎲",
 };
 
+function formatTraceValue(value: string | number | null | undefined): string | null {
+  if (value == null || value === "") return null;
+  return String(value);
+}
+
 export default function RecommendationRow({
   reason,
   type,
@@ -124,6 +129,26 @@ export default function RecommendationRow({
               cdaUrl={r.cda_url}
               onClick={() => onClickMovie(r, type)}
             />
+            {r.trace ? (
+              <details className="absolute left-2 top-2 z-20 max-w-[calc(100%-1rem)]">
+                <summary className="cursor-pointer list-none rounded-md bg-black/70 px-2 py-1 text-[10px] font-medium uppercase tracking-[0.18em] text-cyan-200 backdrop-blur-sm">
+                  Trace
+                </summary>
+                <div className="mt-1 rounded-lg border border-cyan-500/30 bg-black/90 p-2 text-[11px] text-cyan-50 shadow-xl">
+                  <div><span className="text-cyan-300">engine:</span> {r.trace.engine}</div>
+                  <div><span className="text-cyan-300">source:</span> {r.trace.source}</div>
+                  {formatTraceValue(r.trace.seedKind) ? (
+                    <div><span className="text-cyan-300">seed:</span> {formatTraceValue(r.trace.seedKind)}</div>
+                  ) : null}
+                  {formatTraceValue(r.trace.seedName ?? r.trace.seedTitle) ? (
+                    <div><span className="text-cyan-300">label:</span> {formatTraceValue(r.trace.seedName ?? r.trace.seedTitle)}</div>
+                  ) : null}
+                  {formatTraceValue(r.trace.seedId ?? r.trace.seedTmdbId) ? (
+                    <div><span className="text-cyan-300">id:</span> {formatTraceValue(r.trace.seedId ?? r.trace.seedTmdbId)}</div>
+                  ) : null}
+                </div>
+              </details>
+            ) : null}
             <CardActionStack
               actions={[
                 {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,5 +1,6 @@
 import Database from "better-sqlite3";
 import path from "path";
+import type { RecommendationTrace } from "@/lib/recommendation-trace";
 
 export interface Movie {
   id: number;
@@ -199,6 +200,7 @@ export function initDb(db: Database.Database): void {
       pl_title TEXT,
       cda_url TEXT,
       description TEXT,
+      trace TEXT,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       UNIQUE(tmdb_id, engine)
     );
@@ -210,6 +212,9 @@ export function initDb(db: Database.Database): void {
   ).map((c) => c.name);
   if (!recMovieCols.includes("description")) {
     db.exec("ALTER TABLE recommended_movies ADD COLUMN description TEXT");
+  }
+  if (!recMovieCols.includes("trace")) {
+    db.exec("ALTER TABLE recommended_movies ADD COLUMN trace TEXT");
   }
 
   // Migration: old recommendation_cache had 'id' column, new one has 'engine'
@@ -483,7 +488,43 @@ export interface RecommendedMovie {
   pl_title: string | null;
   cda_url: string | null;
   description: string | null;
+  trace: RecommendationTrace | null;
   created_at: string;
+}
+
+interface RecommendedMovieRow {
+  id: number;
+  tmdb_id: number;
+  engine: string;
+  reason: string;
+  title: string;
+  year: number | null;
+  genre: string | null;
+  rating: number | null;
+  poster_url: string | null;
+  pl_title: string | null;
+  cda_url: string | null;
+  description: string | null;
+  trace: string | null;
+  created_at: string;
+}
+
+function parseRecommendationTrace(
+  trace: string | null,
+): RecommendationTrace | null {
+  if (!trace) return null;
+  try {
+    return JSON.parse(trace) as RecommendationTrace;
+  } catch {
+    return null;
+  }
+}
+
+function mapRecommendedMovieRow(row: RecommendedMovieRow): RecommendedMovie {
+  return {
+    ...row,
+    trace: parseRecommendationTrace(row.trace),
+  };
 }
 
 export function saveRecommendedMovies(
@@ -497,14 +538,20 @@ export function saveRecommendedMovies(
     genre: string | null;
     rating: number | null;
     poster_url: string | null;
+    trace?: RecommendationTrace;
   }[],
 ): void {
   const stmt = db.prepare(`
-    INSERT OR IGNORE INTO recommended_movies (tmdb_id, engine, reason, title, year, genre, rating, poster_url)
-    VALUES (@tmdb_id, @engine, @reason, @title, @year, @genre, @rating, @poster_url)
+    INSERT OR IGNORE INTO recommended_movies (tmdb_id, engine, reason, title, year, genre, rating, poster_url, trace)
+    VALUES (@tmdb_id, @engine, @reason, @title, @year, @genre, @rating, @poster_url, @trace)
   `);
   for (const m of movies) {
-    stmt.run({ ...m, engine, reason });
+    stmt.run({
+      ...m,
+      engine,
+      reason,
+      trace: m.trace ? JSON.stringify(m.trace) : null,
+    });
   }
 }
 
@@ -537,16 +584,16 @@ export function getRecommendedMovies(
        LIMIT 1),
       rm.poster_url
     ) AS poster_url,
-    rm.pl_title, rm.cda_url, rm.description, rm.created_at
+    rm.pl_title, rm.cda_url, rm.description, rm.trace, rm.created_at
   `;
   if (engine) {
-    return db
+    return (db
       .prepare(`SELECT ${cols} FROM recommended_movies rm WHERE rm.engine = ? ORDER BY rm.rating DESC`)
-      .all(engine) as RecommendedMovie[];
+      .all(engine) as RecommendedMovieRow[]).map(mapRecommendedMovieRow);
   }
-  return db
+  return (db
     .prepare(`SELECT ${cols} FROM recommended_movies rm ORDER BY rm.engine, rm.rating DESC`)
-    .all() as RecommendedMovie[];
+    .all() as RecommendedMovieRow[]).map(mapRecommendedMovieRow);
 }
 
 export function updateRecommendedMovie(

--- a/lib/engines/actor.ts
+++ b/lib/engines/actor.ts
@@ -1,5 +1,6 @@
 import { discoverByPerson, getMovieCredits } from "../tmdb";
 import {
+  attachTrace,
   filterResults,
   type EngineContext,
   type RecommendationGroup,
@@ -55,7 +56,12 @@ export async function actorEngine(
       groups.push({
         reason: `Starring ${name}`,
         type: "actor",
-        recommendations: filtered.slice(0, 15),
+        recommendations: attachTrace(filtered.slice(0, 15), {
+          engine: "actor",
+          seedKind: "actor",
+          seedId: topActors[i][0],
+          seedName: name,
+        }),
       });
     }
   });

--- a/lib/engines/cda.ts
+++ b/lib/engines/cda.ts
@@ -50,6 +50,12 @@ export async function cdaEngine(
       tmdb_id: m.tmdb_id,
       imdb_id: null,
       cda_url: m.cda_url || undefined,
+      trace: m.trace ?? {
+        engine: "cda",
+        source: "recommended_movies",
+        seedKind: "cda",
+        seedName: primaryGenre,
+      },
     });
   }
 

--- a/lib/engines/director.ts
+++ b/lib/engines/director.ts
@@ -1,5 +1,6 @@
 import { discoverByPerson, getMovieCredits } from "../tmdb";
 import {
+  attachTrace,
   filterResults,
   type EngineContext,
   type RecommendationGroup,
@@ -56,7 +57,12 @@ export async function directorEngine(
       groups.push({
         reason: `More from director ${name}`,
         type: "director",
-        recommendations: filtered.slice(0, 15),
+        recommendations: attachTrace(filtered.slice(0, 15), {
+          engine: "director",
+          seedKind: "director",
+          seedId: topDirectors[i][0],
+          seedName: name,
+        }),
       });
     }
   });

--- a/lib/engines/genre.ts
+++ b/lib/engines/genre.ts
@@ -1,6 +1,7 @@
 import { discoverByGenre, genreNameToId } from "../tmdb";
 import { parseGenreLabels } from "../utils";
 import {
+  attachTrace,
   filterResults,
   type EngineContext,
   type RecommendationGroup,
@@ -66,7 +67,12 @@ export async function genreEngine(
       groups.push({
         reason: `Because you love ${genreName}`,
         type: "genre",
-        recommendations: filtered.slice(0, 15),
+        recommendations: attachTrace(filtered.slice(0, 15), {
+          engine: "genre",
+          seedKind: "genre",
+          seedId: genreId,
+          seedName: genreName,
+        }),
       });
     }
   }

--- a/lib/engines/index.ts
+++ b/lib/engines/index.ts
@@ -1,5 +1,9 @@
 import type { Movie } from "../db";
 import type { TmdbSearchResult } from "../tmdb";
+import type {
+  RecommendationSourceKind,
+  RecommendationTrace,
+} from "../recommendation-trace";
 import { genreEngine } from "./genre";
 import { directorEngine } from "./director";
 import { actorEngine } from "./actor";
@@ -102,6 +106,41 @@ export function enrichWithCda(
     if (cdaUrl) return { ...r, cda_url: cdaUrl };
     return r;
   });
+}
+
+export function attachTrace(
+  results: TmdbSearchResult[],
+  trace: Omit<RecommendationTrace, "source"> & {
+    source?: RecommendationSourceKind;
+  },
+): TmdbSearchResult[] {
+  return results.map((result) => ({
+    ...result,
+    trace: {
+      ...trace,
+      source: trace.source ?? "live_tmdb",
+    },
+  }));
+}
+
+export function overrideTraceSource(
+  groups: RecommendationGroup[],
+  source: RecommendationSourceKind,
+): RecommendationGroup[] {
+  return groups.map((group) => ({
+    ...group,
+    recommendations: group.recommendations.map((recommendation) =>
+      recommendation.trace
+        ? {
+            ...recommendation,
+            trace: {
+              ...recommendation.trace,
+              source,
+            },
+          }
+        : recommendation,
+    ),
+  }));
 }
 
 export function buildContext(

--- a/lib/engines/movie.ts
+++ b/lib/engines/movie.ts
@@ -1,5 +1,6 @@
 import { getTmdbRecommendations, getTmdbSimilar } from "../tmdb";
 import {
+  attachTrace,
   filterResults,
   type EngineContext,
   type RecommendationGroup,
@@ -47,7 +48,12 @@ export async function movieEngine(
       groups.push({
         reason: `Because you loved ${seeds[i].title}`,
         type: "movie",
-        recommendations: filtered,
+        recommendations: attachTrace(filtered, {
+          engine: "movie",
+          seedKind: "movie",
+          seedTmdbId: seeds[i].tmdb_id,
+          seedTitle: seeds[i].title,
+        }),
       });
     }
   });

--- a/lib/recommendation-trace.ts
+++ b/lib/recommendation-trace.ts
@@ -1,0 +1,21 @@
+export type RecommendationSourceKind =
+  | "live_tmdb"
+  | "recommendation_cache"
+  | "recommended_movies";
+
+export type RecommendationSeedKind =
+  | "director"
+  | "actor"
+  | "genre"
+  | "movie"
+  | "cda";
+
+export interface RecommendationTrace {
+  engine: string;
+  source: RecommendationSourceKind;
+  seedKind?: RecommendationSeedKind;
+  seedId?: number | null;
+  seedName?: string | null;
+  seedTmdbId?: number | null;
+  seedTitle?: string | null;
+}

--- a/lib/tmdb.ts
+++ b/lib/tmdb.ts
@@ -1,4 +1,5 @@
 import { getDb, getSetting } from "@/lib/db";
+import type { RecommendationTrace } from "@/lib/recommendation-trace";
 import type { TmdbHealthSnapshot } from "@/lib/tmdb-health";
 
 const TMDB_BASE = "https://api.themoviedb.org/3";
@@ -213,6 +214,7 @@ export interface TmdbSearchResult {
   imdb_id: string | null;
   cda_url?: string | null;
   pl_title?: string | null;
+  trace?: RecommendationTrace;
 }
 
 function normalizeSearchText(value: string): string {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,9 @@
 import type { TmdbSearchResult } from "@/lib/tmdb";
+export type {
+  RecommendationSourceKind,
+  RecommendationSeedKind,
+  RecommendationTrace,
+} from "@/lib/recommendation-trace";
 
 export type SortOption =
   | "user_rating"


### PR DESCRIPTION
Closes #88

Implemented issue `#88` end-to-end, including trace types, engine population, cache/DB persistence, UI exposure, and tests, then updated agent memory.

---
Implemented via TamTam from issue [#88](https://github.com/3h4x/film-pick/issues/88).