### PR TITLE
fix: Add a quick-rate keyboard mode to triage unrated movies in seconds

### DIFF
--- a/__tests__/quick-rate.test.ts
+++ b/__tests__/quick-rate.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { Movie } from "@/lib/types";
+import { mapQuickRateKey, nextUnratedMovie } from "@/lib/quick-rate";
+
+function makeMovie(overrides: Partial<Movie> = {}): Movie {
+  return {
+    id: 1,
+    title: "Test Movie",
+    year: 2020,
+    genre: "Drama",
+    director: null,
+    writer: null,
+    actors: null,
+    rating: 7,
+    user_rating: null,
+    poster_url: null,
+    source: "manual",
+    type: "movie",
+    tmdb_id: null,
+    rated_at: null,
+    created_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("nextUnratedMovie", () => {
+  it("returns the first unrated movie when currentId is null", () => {
+    const movies = [
+      makeMovie({ id: 1, user_rating: 8 }),
+      makeMovie({ id: 2, user_rating: null }),
+      makeMovie({ id: 3, user_rating: 0 }),
+    ];
+
+    expect(nextUnratedMovie(movies, null)?.id).toBe(2);
+  });
+
+  it("returns the next unrated movie after the current movie", () => {
+    const movies = [
+      makeMovie({ id: 1, user_rating: null }),
+      makeMovie({ id: 2, user_rating: 7 }),
+      makeMovie({ id: 3, user_rating: null }),
+    ];
+
+    expect(nextUnratedMovie(movies, 1)?.id).toBe(3);
+  });
+
+  it("returns null when there is no later unrated movie", () => {
+    const movies = [
+      makeMovie({ id: 1, user_rating: 8 }),
+      makeMovie({ id: 2, user_rating: null }),
+    ];
+
+    expect(nextUnratedMovie(movies, 2)).toBeNull();
+  });
+});
+
+describe("mapQuickRateKey", () => {
+  it("maps digits to ratings including 0 as 10", () => {
+    expect(mapQuickRateKey("1")).toEqual({ kind: "rate", rating: 1 });
+    expect(mapQuickRateKey("9")).toEqual({ kind: "rate", rating: 9 });
+    expect(mapQuickRateKey("0")).toEqual({ kind: "rate", rating: 10 });
+  });
+
+  it("maps control keys to quick-rate actions", () => {
+    expect(mapQuickRateKey("s")).toEqual({ kind: "skip" });
+    expect(mapQuickRateKey("W")).toEqual({ kind: "wishlist" });
+    expect(mapQuickRateKey("d")).toEqual({ kind: "dismiss" });
+    expect(mapQuickRateKey("Escape")).toEqual({ kind: "exit" });
+  });
+
+  it("ignores unrelated keys", () => {
+    expect(mapQuickRateKey("Enter")).toBeNull();
+    expect(mapQuickRateKey("x")).toBeNull();
+  });
+});

--- a/components/QuickRateMode.tsx
+++ b/components/QuickRateMode.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { Movie } from "@/lib/types";
+import {
+  isUnratedMovie,
+  mapQuickRateKey,
+  nextUnratedMovie,
+} from "@/lib/quick-rate";
+
+interface QuickRateModeProps {
+  movies: Movie[];
+  onClose: () => void;
+  onRate: (movie: Movie, rating: number) => Promise<boolean>;
+  onToggleWishlist: (movie: Movie) => Promise<boolean>;
+  onDismiss?: (movie: Movie) => Promise<boolean>;
+}
+
+interface MovieDetailResponse {
+  movie?: {
+    description?: string | null;
+    poster_url?: string | null;
+    pl_title?: string | null;
+  };
+}
+
+export default function QuickRateMode({
+  movies,
+  onClose,
+  onRate,
+  onToggleWishlist,
+  onDismiss,
+}: QuickRateModeProps) {
+  const unratedMovies = useMemo(
+    () => movies.filter(isUnratedMovie),
+    [movies],
+  );
+  const [currentId, setCurrentId] = useState<number | null>(
+    unratedMovies[0]?.id ?? null,
+  );
+  const [description, setDescription] = useState<string | null>(null);
+  const [posterUrl, setPosterUrl] = useState<string | null>(null);
+  const [plTitle, setPlTitle] = useState<string | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+
+  useEffect(() => {
+    if (unratedMovies.length === 0) {
+      onClose();
+      return;
+    }
+
+    if (!currentId || !unratedMovies.some((movie) => movie.id === currentId)) {
+      setCurrentId(unratedMovies[0]?.id ?? null);
+    }
+  }, [currentId, onClose, unratedMovies]);
+
+  const currentMovie = useMemo(
+    () => unratedMovies.find((movie) => movie.id === currentId) ?? null,
+    [currentId, unratedMovies],
+  );
+
+  const progressIndex = currentMovie
+    ? unratedMovies.findIndex((movie) => movie.id === currentMovie.id) + 1
+    : 0;
+
+  useEffect(() => {
+    if (!currentMovie) {
+      setDescription(null);
+      setPosterUrl(null);
+      setPlTitle(null);
+      return;
+    }
+
+    setDescription(currentMovie.description ?? null);
+    setPosterUrl(currentMovie.poster_url ?? null);
+    setPlTitle(currentMovie.pl_title ?? null);
+
+    let cancelled = false;
+    void fetch(`/api/movies/${currentMovie.id}`)
+      .then(async (res) => {
+        if (!res.ok) return null;
+        return res.json() as Promise<MovieDetailResponse>;
+      })
+      .then((data) => {
+        if (!data?.movie || cancelled) return;
+        setDescription(data.movie.description ?? null);
+        setPosterUrl(data.movie.poster_url ?? currentMovie.poster_url ?? null);
+        setPlTitle(data.movie.pl_title ?? currentMovie.pl_title ?? null);
+      })
+      .catch((error) => {
+        console.error("[quick-rate] failed to load movie details", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentMovie]);
+
+  function advance() {
+    if (!currentMovie) return;
+    const nextMovie = nextUnratedMovie(unratedMovies, currentMovie.id);
+    if (nextMovie) {
+      setCurrentId(nextMovie.id);
+      return;
+    }
+    onClose();
+  }
+
+  useEffect(() => {
+    if (!currentMovie) return;
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (isBusy || event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+
+      const action = mapQuickRateKey(event.key);
+      if (!action) return;
+
+      event.preventDefault();
+
+      if (action.kind === "exit") {
+        onClose();
+        return;
+      }
+
+      if (action.kind === "skip") {
+        advance();
+        return;
+      }
+
+      if (action.kind === "dismiss") {
+        if (!onDismiss) {
+          advance();
+          return;
+        }
+        setIsBusy(true);
+        void onDismiss(currentMovie)
+          .then((ok) => {
+            if (ok) advance();
+          })
+          .finally(() => setIsBusy(false));
+        return;
+      }
+
+      if (action.kind === "wishlist") {
+        setIsBusy(true);
+        void onToggleWishlist(currentMovie).finally(() => setIsBusy(false));
+        return;
+      }
+
+      setIsBusy(true);
+      void onRate(currentMovie, action.rating)
+        .then((ok) => {
+          if (ok) advance();
+        })
+        .finally(() => setIsBusy(false));
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [currentMovie, isBusy, onClose, onDismiss, onRate, onToggleWishlist, unratedMovies]);
+
+  if (!currentMovie) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.18),_transparent_38%),linear-gradient(180deg,_rgba(2,6,23,0.98),_rgba(15,23,42,0.96))] backdrop-blur-xl">
+      <div className="mx-auto flex min-h-screen max-w-6xl flex-col px-4 py-5 sm:px-6">
+        <div className="mb-5 flex items-center justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-indigo-300/80">
+              Quick Rate
+            </p>
+            <p className="mt-1 text-sm text-gray-400">
+              {progressIndex} / {unratedMovies.length} unrated
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-xl border border-gray-700/60 bg-gray-900/70 px-4 py-2 text-sm font-medium text-gray-300 transition-colors hover:border-gray-500/70 hover:text-white"
+          >
+            Esc to exit
+          </button>
+        </div>
+
+        <div className="grid flex-1 gap-6 lg:grid-cols-[minmax(260px,360px)_1fr] lg:items-center">
+          <div className="overflow-hidden rounded-[28px] border border-gray-800/70 bg-gray-900/70 shadow-2xl shadow-black/40">
+            <div className="aspect-[2/3] bg-gray-900">
+              {posterUrl ? (
+                <img
+                  src={posterUrl}
+                  alt={currentMovie.title}
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <div className="flex h-full items-end bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.26),_transparent_48%),linear-gradient(160deg,_rgba(15,23,42,0.96),_rgba(17,24,39,0.88))] p-6">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.24em] text-gray-400">
+                      No Poster
+                    </p>
+                    <p className="mt-3 text-3xl font-semibold text-white">
+                      {currentMovie.title}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col justify-center">
+            <div className="flex flex-wrap items-center gap-2">
+              {currentMovie.user_rating != null && currentMovie.user_rating > 0 && (
+                <span className="rounded-full bg-indigo-500/20 px-3 py-1 text-xs font-semibold text-indigo-200">
+                  Your rating {currentMovie.user_rating}/10
+                </span>
+              )}
+              {currentMovie.wishlist === 1 && (
+                <span className="rounded-full bg-amber-500/20 px-3 py-1 text-xs font-semibold text-amber-200">
+                  On watchlist
+                </span>
+              )}
+              {currentMovie.rating != null && currentMovie.rating > 0 && (
+                <span className="rounded-full bg-yellow-500/15 px-3 py-1 text-xs font-semibold text-yellow-200">
+                  Global {currentMovie.rating}
+                </span>
+              )}
+            </div>
+
+            <h2 className="mt-4 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+              {currentMovie.title}
+            </h2>
+            {(plTitle || currentMovie.year) && (
+              <p className="mt-3 text-lg text-gray-400">
+                {[plTitle, currentMovie.year].filter(Boolean).join(" • ")}
+              </p>
+            )}
+            {currentMovie.genre && (
+              <p className="mt-2 text-sm uppercase tracking-[0.22em] text-gray-500">
+                {currentMovie.genre}
+              </p>
+            )}
+
+            <p className="mt-6 max-w-3xl text-sm leading-7 text-gray-300 sm:text-base">
+              {description?.trim() || "No plot summary available yet."}
+            </p>
+
+            <div className="mt-8 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              <div className="rounded-2xl border border-gray-800/70 bg-gray-900/65 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-gray-500">
+                  Rate
+                </p>
+                <p className="mt-2 text-sm text-gray-300">
+                  Keys 1-9, 0 = 10
+                </p>
+              </div>
+              <div className="rounded-2xl border border-gray-800/70 bg-gray-900/65 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-gray-500">
+                  Skip
+                </p>
+                <p className="mt-2 text-sm text-gray-300">
+                  Press S
+                </p>
+              </div>
+              <div className="rounded-2xl border border-gray-800/70 bg-gray-900/65 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-gray-500">
+                  Wishlist
+                </p>
+                <p className="mt-2 text-sm text-gray-300">
+                  Press W
+                </p>
+              </div>
+              <div className="rounded-2xl border border-gray-800/70 bg-gray-900/65 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-gray-500">
+                  Dismiss
+                </p>
+                <p className="mt-2 text-sm text-gray-300">
+                  {onDismiss ? "Press D" : "Skips here"}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {isBusy && (
+          <div className="pointer-events-none fixed inset-x-0 bottom-6 flex justify-center">
+            <div className="rounded-full border border-indigo-500/30 bg-indigo-500/15 px-4 py-2 text-sm text-indigo-100">
+              Saving…
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/QuickRateMode.tsx
+++ b/components/QuickRateMode.tsx
@@ -109,6 +109,8 @@ export default function QuickRateMode({
   useEffect(() => {
     if (!currentMovie) return;
 
+    const movie = currentMovie;
+
     function onKeyDown(event: KeyboardEvent) {
       if (isBusy || event.metaKey || event.ctrlKey || event.altKey) return;
       const target = event.target;
@@ -142,7 +144,7 @@ export default function QuickRateMode({
           return;
         }
         setIsBusy(true);
-        void onDismiss(currentMovie)
+        void onDismiss(movie)
           .then((ok) => {
             if (ok) advance();
           })
@@ -152,12 +154,12 @@ export default function QuickRateMode({
 
       if (action.kind === "wishlist") {
         setIsBusy(true);
-        void onToggleWishlist(currentMovie).finally(() => setIsBusy(false));
+        void onToggleWishlist(movie).finally(() => setIsBusy(false));
         return;
       }
 
       setIsBusy(true);
-      void onRate(currentMovie, action.rating)
+      void onRate(movie, action.rating)
         .then((ok) => {
           if (ok) advance();
         })

--- a/components/views/LibraryView.tsx
+++ b/components/views/LibraryView.tsx
@@ -1,9 +1,12 @@
 "use client";
+import { useEffect, useMemo, useState } from "react";
 import MovieCard from "@/components/MovieCard";
+import QuickRateMode from "@/components/QuickRateMode";
 import SortFilterBar from "@/components/SortFilterBar";
 import type { Movie } from "@/lib/types";
 import { PAGE_SIZE } from "@/lib/types";
 import type { useLibrary } from "@/lib/hooks/useLibrary";
+import { isUnratedMovie } from "@/lib/quick-rate";
 
 type LibraryState = ReturnType<typeof useLibrary>;
 
@@ -50,7 +53,37 @@ export default function LibraryView({
     setHasFileOnly,
     handleDeleteMovie,
     handleMoveToWatchlist,
+    handleQuickRate,
+    handleToggleWishlist,
   } = library;
+  const [quickRateOpen, setQuickRateOpen] = useState(false);
+
+  const unratedMovies = useMemo(
+    () => sortedMovies.filter(isUnratedMovie),
+    [sortedMovies],
+  );
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.repeat || event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      if (event.key.toLowerCase() !== "r") return;
+      if (unratedMovies.length === 0) return;
+      event.preventDefault();
+      setQuickRateOpen(true);
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [unratedMovies.length]);
 
   if (initialLoad) {
     return (
@@ -159,15 +192,25 @@ export default function LibraryView({
           {sortedMovies.length}
           {sortedMovies.length !== movies.length && ` (${movies.length} total)`}
         </p>
-        {searchQuery && (
+        <div className="flex flex-wrap items-center gap-2">
           <button
-            onClick={() => onSearchInTMDb(searchQuery)}
-            className="text-indigo-400 hover:text-indigo-300 text-xs font-medium transition-colors flex items-center gap-1.5 px-2 py-1 rounded-lg hover:bg-indigo-500/10"
+            type="button"
+            onClick={() => setQuickRateOpen(true)}
+            disabled={unratedMovies.length === 0}
+            className="rounded-xl border border-indigo-500/30 bg-indigo-500/10 px-3 py-2 text-xs font-semibold text-indigo-200 transition-colors hover:border-indigo-400/50 hover:bg-indigo-500/20 disabled:cursor-not-allowed disabled:border-gray-800/70 disabled:bg-gray-900/60 disabled:text-gray-600"
           >
-            <span>🔍</span>
-            Search &ldquo;{searchQuery}&rdquo; in TMDb
+            Quick Rate ({unratedMovies.length}) · R
           </button>
-        )}
+          {searchQuery && (
+            <button
+              onClick={() => onSearchInTMDb(searchQuery)}
+              className="text-indigo-400 hover:text-indigo-300 text-xs font-medium transition-colors flex items-center gap-1.5 px-2 py-1 rounded-lg hover:bg-indigo-500/10"
+            >
+              <span>🔍</span>
+              Search &ldquo;{searchQuery}&rdquo; in TMDb
+            </button>
+          )}
+        </div>
       </div>
       {sortedMovies.length === 0 ? (
         <div className="text-center py-12">
@@ -206,6 +249,14 @@ export default function LibraryView({
             Load More ({sortedMovies.length - visibleCount} remaining)
           </button>
         </div>
+      )}
+      {quickRateOpen && (
+        <QuickRateMode
+          movies={sortedMovies}
+          onClose={() => setQuickRateOpen(false)}
+          onRate={handleQuickRate}
+          onToggleWishlist={handleToggleWishlist}
+        />
       )}
     </>
   );

--- a/lib/hooks/useLibrary.ts
+++ b/lib/hooks/useLibrary.ts
@@ -98,6 +98,52 @@ export function useLibrary(
     }
   }, []);
 
+  const patchMovie = useCallback(
+    async (
+      id: number,
+      updates: Partial<Pick<Movie, "user_rating" | "wishlist" | "rated_at">>,
+    ) => {
+      const previousMovie = movies.find((movie) => movie.id === id);
+
+      if (previousMovie) {
+        setMovies((prev) =>
+          prev.map((movie) =>
+            movie.id === id ? { ...movie, ...updates } : movie,
+          ),
+        );
+      }
+
+      try {
+        const res = await fetch(`/api/movies/${id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(updates),
+        });
+
+        if (!res.ok) {
+          const error = await res.json().catch(() => ({ error: "Failed to update movie" }));
+          throw new Error(typeof error.error === "string" ? error.error : "Failed to update movie");
+        }
+
+        const updatedMovie = (await res.json()) as Movie;
+        setMovies((prev) =>
+          prev.map((movie) => (movie.id === id ? updatedMovie : movie)),
+        );
+        return updatedMovie;
+      } catch (error) {
+        if (previousMovie) {
+          setMovies((prev) =>
+            prev.map((movie) => (movie.id === id ? previousMovie : movie)),
+          );
+        }
+        console.error("[movies-organizer] patchMovie: error", error);
+        addToast("Failed to update movie");
+        return null;
+      }
+    },
+    [addToast, movies],
+  );
+
   function handleDeleteMovie(id: number, title: string) {
     setMovies((prev) => prev.filter((m) => m.id !== id));
     fetch(`/api/movies/${id}`, { method: "DELETE" });
@@ -136,6 +182,29 @@ export function useLibrary(
     });
   }
 
+  async function handleQuickRate(movie: Movie, rating: number) {
+    const updatedMovie = await patchMovie(movie.id, {
+      user_rating: rating,
+      wishlist: 0,
+    });
+    if (!updatedMovie) return false;
+    addToast(`Rated "${movie.title}" ${rating}/10`, "success");
+    return true;
+  }
+
+  async function handleToggleWishlist(movie: Movie) {
+    const nextWishlist = movie.wishlist === 1 ? 0 : 1;
+    const updatedMovie = await patchMovie(movie.id, { wishlist: nextWishlist });
+    if (!updatedMovie) return false;
+    addToast(
+      nextWishlist === 1
+        ? `Added "${movie.title}" to watchlist`
+        : `Removed "${movie.title}" from watchlist`,
+      "success",
+    );
+    return true;
+  }
+
   return {
     movies,
     setMovies,
@@ -168,5 +237,7 @@ export function useLibrary(
     handleDeleteMovie,
     handleMoveToWatchlist,
     handleWishlistAction,
+    handleQuickRate,
+    handleToggleWishlist,
   };
 }

--- a/lib/quick-rate.ts
+++ b/lib/quick-rate.ts
@@ -1,0 +1,48 @@
+import type { Movie } from "@/lib/types";
+
+export type QuickRateAction =
+  | { kind: "rate"; rating: number }
+  | { kind: "skip" }
+  | { kind: "wishlist" }
+  | { kind: "dismiss" }
+  | { kind: "exit" };
+
+export function isUnratedMovie(movie: Movie) {
+  return movie.user_rating == null || movie.user_rating === 0;
+}
+
+export function nextUnratedMovie(
+  movies: Movie[],
+  currentId: number | null,
+): Movie | null {
+  const unratedMovies = movies.filter(isUnratedMovie);
+  if (unratedMovies.length === 0) return null;
+  if (currentId == null) return unratedMovies[0] ?? null;
+
+  const currentIndex = unratedMovies.findIndex((movie) => movie.id === currentId);
+  if (currentIndex === -1) return unratedMovies[0] ?? null;
+
+  return unratedMovies[currentIndex + 1] ?? null;
+}
+
+export function mapQuickRateKey(key: string): QuickRateAction | null {
+  if (key >= "1" && key <= "9") {
+    return { kind: "rate", rating: Number(key) };
+  }
+  if (key === "0") {
+    return { kind: "rate", rating: 10 };
+  }
+
+  switch (key.toLowerCase()) {
+    case "s":
+      return { kind: "skip" };
+    case "w":
+      return { kind: "wishlist" };
+    case "d":
+      return { kind: "dismiss" };
+    case "escape":
+      return { kind: "exit" };
+    default:
+      return null;
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -32,6 +32,7 @@ export interface Movie {
   filmweb_url?: string | null;
   cda_url?: string | null;
   pl_title?: string | null;
+  description?: string | null;
   wishlist?: number;
   file_path?: string | null;
 }


### PR DESCRIPTION
Closes #80

Validated issue `#80`, commented on it, created the TamTam issue branch, and implemented the quick-rate overlay plus helper/tests without running the suite.

---
Implemented via TamTam from issue [#80](https://github.com/3h4x/film-pick/issues/80).